### PR TITLE
fix 2 bugs - response channel size and response blocking config

### DIFF
--- a/libhoney.go
+++ b/libhoney.go
@@ -21,6 +21,15 @@ const (
 	defaultSampleRate = 1
 	defaultAPIHost    = "https://api.honeycomb.io/"
 	version           = "1.1.0"
+
+	// defaultmaxBatchSize how many events to collect in a batch
+	defaultmaxBatchSize = 50
+	// defaultbatchTimeout how frequently to send unfilled batches
+	defaultbatchTimeout = 100 * time.Millisecond
+	// defaultmaxConcurrentBatches how many batches to maintain in parallel
+	defaultmaxConcurrentBatches = 10
+	// defaultpendingWorkCapacity how many events to queue up for busy batches
+	defaultpendingWorkCapacity = 10000
 )
 
 var (
@@ -167,6 +176,18 @@ func Init(config Config) error {
 	if config.APIHost == "" {
 		config.APIHost = defaultAPIHost
 	}
+	if config.MaxBatchSize == 0 {
+		config.MaxBatchSize = defaultmaxBatchSize
+	}
+	if config.SendFrequency == 0 {
+		config.SendFrequency = defaultbatchTimeout
+	}
+	if config.MaxConcurrentBatches == 0 {
+		config.MaxConcurrentBatches = defaultmaxConcurrentBatches
+	}
+	if config.PendingWorkCapacity == 0 {
+		config.PendingWorkCapacity = defaultpendingWorkCapacity
+	}
 
 	sd, _ = statsd.New(statsd.Prefix("libhoney"))
 
@@ -179,6 +200,7 @@ func Init(config Config) error {
 		maxConcurrentBatches: config.MaxConcurrentBatches,
 		pendingWorkCapacity:  config.PendingWorkCapacity,
 		blockOnSend:          config.BlockOnSend,
+		blockOnResponses:     config.BlockOnResponse,
 	}
 
 	if err := tx.Start(); err != nil {

--- a/libhoney_test.go
+++ b/libhoney_test.go
@@ -28,6 +28,7 @@ func TestLibhoney(t *testing.T) {
 	}
 	err := Init(conf)
 	testOK(t, err)
+	testEquals(t, cap(responses), 2*defaultpendingWorkCapacity)
 }
 
 func TestNewEvent(t *testing.T) {

--- a/transmission.go
+++ b/transmission.go
@@ -23,17 +23,6 @@ import (
 	"github.com/facebookgo/muster"
 )
 
-const (
-	// defaultmaxBatchSize how many events to collect in a batch
-	defaultmaxBatchSize = 50
-	// defaultbatchTimeout how frequently to send unfilled batches
-	defaultbatchTimeout = 100 * time.Millisecond
-	// defaultmaxConcurrentBatches how many batches to maintain in parallel
-	defaultmaxConcurrentBatches = 10
-	// defaultpendingWorkCapacity how many events to queue up for busy batches
-	defaultpendingWorkCapacity = 10000
-)
-
 type txClient interface {
 	Start() error
 	Stop() error
@@ -52,21 +41,9 @@ type txDefaultClient struct {
 }
 
 func (t *txDefaultClient) Start() error {
-	if t.maxBatchSize == 0 {
-		t.maxBatchSize = defaultmaxBatchSize
-	}
 	t.muster.MaxBatchSize = t.maxBatchSize
-	if t.batchTimeout == 0 {
-		t.batchTimeout = defaultbatchTimeout
-	}
 	t.muster.BatchTimeout = t.batchTimeout
-	if t.maxConcurrentBatches == 0 {
-		t.maxConcurrentBatches = defaultmaxConcurrentBatches
-	}
 	t.muster.MaxConcurrentBatches = t.maxConcurrentBatches
-	if t.pendingWorkCapacity == 0 {
-		t.pendingWorkCapacity = defaultpendingWorkCapacity
-	}
 	t.muster.PendingWorkCapacity = t.pendingWorkCapacity
 	t.muster.BatchMaker = func() muster.Batch {
 		return &batch{


### PR DESCRIPTION
move initialization of default values to libhoney so responses queue gets created with the correct capacity. Propogate config setting to block on responses.