### PR TITLE
Refactor, make tests verify blocking behavior, make Init() not required

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -4,9 +4,9 @@ Package libhoney is a client library for sending data to https://honeycomb.io
 Summary
 
 libhoney aims to make it as easy as possible to create events and send them on
-into honeycomb.
+into Honeycomb.
 
-See https://docs.honeycomb.io for background on how to use this library
+See https://honeycomb.io/docs for background on this library.
 
 Look in the examples/ directory for a complete example using libhoney.
 */

--- a/libhoney.go
+++ b/libhoney.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"net/http"
 	"reflect"
 	"strings"
 	"sync"
@@ -113,6 +114,11 @@ type Config struct {
 	SendFrequency        time.Duration // how often to send off batches
 	MaxConcurrentBatches uint          // how many batches can be inflight simultaneously
 	PendingWorkCapacity  uint          // how many events to allow to pile up
+
+	// Transport can be provided to the http.Client attempting to talk to
+	// Honeycomb servers. Intended for use in tests in order to assert on
+	// expected behavior.
+	Transport http.RoundTripper
 }
 
 type Event struct {
@@ -206,6 +212,7 @@ func Init(config Config) error {
 		pendingWorkCapacity:  config.PendingWorkCapacity,
 		blockOnSend:          config.BlockOnSend,
 		blockOnResponses:     config.BlockOnResponse,
+		transport:            config.Transport,
 	}
 
 	if err := tx.Start(); err != nil {

--- a/libhoney_test.go
+++ b/libhoney_test.go
@@ -14,7 +14,7 @@ import (
 // tests interact with the same variables in a way that is not like how it
 // would be used. This function resets things to a blank state.
 func resetPackageVars() {
-	globalState = &Builder{}
+	defaultBuilder = &Builder{}
 	sd, _ = statsd.New(statsd.Mute(true))
 }
 
@@ -411,7 +411,7 @@ func TestBuilderDynFields(t *testing.T) {
 	AddDynamicField("ints", myIntFn)
 	b := NewBuilder()
 	b.AddDynamicField("strs", myStrFn)
-	testEquals(t, len(globalState.dynFields), 1)
+	testEquals(t, len(defaultBuilder.dynFields), 1)
 	testEquals(t, len(b.dynFields), 2)
 
 	ev1 := NewEvent()

--- a/test_helpers.go
+++ b/test_helpers.go
@@ -92,6 +92,3 @@ func (f *fakeNower) Now() time.Time {
 	f.iter += 1
 	return now
 }
-func (f *fakeNower) init() {
-	f.iter = 0
-}

--- a/test_helpers.go
+++ b/test_helpers.go
@@ -52,6 +52,17 @@ func testCommonErr(t testing.TB, actual, expected interface{}, msg []string) {
 	)
 }
 
+func testGetResponse(t testing.TB, ch chan Response) Response {
+	_, file, line, _ := runtime.Caller(2)
+	var resp Response
+	select {
+	case resp = <-ch:
+	case <-time.After(5 * time.Millisecond): // block on read but prevent deadlocking tests
+		t.Errorf("%s:%d: expected response on channel and timed out waiting for it!", filepath.Base(file), line)
+	}
+	return resp
+}
+
 func testIsPlaceholderResponse(t testing.TB, actual Response, msg ...string) {
 	if actual.StatusCode != http.StatusTeapot {
 		message := strings.Join(msg, ", ")

--- a/transmission.go
+++ b/transmission.go
@@ -39,6 +39,8 @@ type txDefaultClient struct {
 	blockOnSend          bool          // whether to block or drop events when the queue fills
 	blockOnResponses     bool          // whether to block or drop responses when the queue fills
 
+	transport http.RoundTripper
+
 	muster muster.Client
 }
 
@@ -50,7 +52,7 @@ func (t *txDefaultClient) Start() error {
 	t.muster.BatchMaker = func() muster.Batch {
 		return &batch{
 			events:           make([]*Event, 0, t.maxBatchSize),
-			httpClient:       &http.Client{},
+			httpClient:       &http.Client{Transport: t.transport},
 			blockOnResponses: t.blockOnResponses,
 		}
 	}
@@ -201,10 +203,4 @@ func (b *batch) sendRequest(e *Event) {
 // nower to make testing easier
 type nower interface {
 	Now() time.Time
-}
-
-type realNower struct{}
-
-func (r *realNower) Now() time.Time {
-	return time.Now().UTC()
 }

--- a/transmission.go
+++ b/transmission.go
@@ -1,6 +1,6 @@
 package libhoney
 
-// Package transmission handles sending events to houd.
+// txClient handles the transmission of events to Honeycomb.
 //
 // Overview
 //
@@ -8,6 +8,7 @@ package libhoney
 // Set any of the public fields for which you want to override the defaults.
 // Call Start() to spin up the background goroutines necessary for transmission
 // Call Add(Event) to queue an event for transmission
+// Ensure Stop() is called to flush all in-flight messages.
 
 import (
 	"bytes"
@@ -18,6 +19,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/facebookgo/muster"
@@ -48,7 +50,6 @@ func (t *txDefaultClient) Start() error {
 	t.muster.BatchMaker = func() muster.Batch {
 		return &batch{
 			events:           make([]*Event, 0, t.maxBatchSize),
-			n:                &realNower{},
 			httpClient:       &http.Client{},
 			blockOnResponses: t.blockOnResponses,
 		}
@@ -114,9 +115,12 @@ func (t *txTestClient) Add(ev *Event) {
 
 type batch struct {
 	events           []*Event
-	n                nower
 	httpClient       *http.Client
 	blockOnResponses bool
+
+	// allows manipulation of the value of "now" for testing
+	testNower   nower
+	testBlocker *sync.WaitGroup
 }
 
 func (b *batch) Add(ev interface{}) {
@@ -125,6 +129,7 @@ func (b *batch) Add(ev interface{}) {
 
 func (b *batch) Fire(notifier muster.Notifier) {
 	defer notifier.Done()
+
 	for _, e := range b.events {
 		b.sendRequest(e)
 	}
@@ -132,7 +137,10 @@ func (b *batch) Fire(notifier muster.Notifier) {
 
 // sendRequest sends an individual request to Honeycomb and returns
 func (b *batch) sendRequest(e *Event) {
-	start := b.n.Now()
+	start := time.Now().UTC()
+	if b.testNower != nil {
+		start = b.testNower.Now()
+	}
 	timestamp := e.Timestamp
 	blob, err := json.Marshal(e.data)
 	if err != nil {
@@ -156,25 +164,31 @@ func (b *batch) sendRequest(e *Event) {
 
 	resp, err := b.httpClient.Do(req)
 
-	dur := b.n.Now().Sub(start)
+	end := time.Now().UTC()
+	if b.testNower != nil {
+		end = b.testNower.Now()
+	}
+	dur := end.Sub(start)
 	evResp := Response{}
-	if !b.blockOnResponses {
-		defer func() {
+	defer func() {
+		if b.blockOnResponses {
+			responses <- evResp
+		} else {
 			select {
 			case responses <- evResp:
 			default:
+				if b.testBlocker != nil {
+					b.testBlocker.Done()
+				}
 			}
-		}()
-	}
+		}
+	}()
 	evResp.Duration = dur
 	evResp.Metadata = e.Metadata
 	if err != nil {
 		// TODO add logging or something to raise this error
 		sd.Increment("send_errors")
 		evResp.Err = err
-		if b.blockOnResponses {
-			responses <- evResp
-		}
 		return
 	}
 	sd.Increment("messages_sent")
@@ -182,9 +196,6 @@ func (b *batch) sendRequest(e *Event) {
 	evResp.StatusCode = resp.StatusCode
 	body, _ := ioutil.ReadAll(resp.Body)
 	evResp.Body = body
-	if b.blockOnResponses {
-		responses <- evResp
-	}
 }
 
 // nower to make testing easier

--- a/transmission_test.go
+++ b/transmission_test.go
@@ -92,21 +92,18 @@ func (f *FakeRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 
 func TestTxSendRequest(t *testing.T) {
 	responses = make(chan Response, 1)
-	fn := &fakeNower{}
-	fn.init()
-	b := &batch{
-		httpClient:  &http.Client{},
-		testNower:   fn,
-		testBlocker: &sync.WaitGroup{},
-	}
-
 	frt := &FakeRoundTripper{}
 	frt.resp = &http.Response{
 		StatusCode: 200,
 		Body:       ioutil.NopCloser(&FakeBody{}),
 	}
-	frt.respErr = nil
-	b.httpClient.Transport = frt
+
+	b := &batch{
+		httpClient:  &http.Client{Transport: frt},
+		testNower:   &fakeNower{},
+		testBlocker: &sync.WaitGroup{},
+	}
+
 	fhData := map[string]interface{}{
 		"foo": "bar",
 	}
@@ -174,7 +171,6 @@ func TestTxSendRequest(t *testing.T) {
 	testEquals(t, len(rsp.Body), 0)
 
 	// test blocking response path, no error
-	fn.init()
 	frt.resp = &http.Response{
 		StatusCode: 200,
 		Body:       ioutil.NopCloser(&FakeBody{}),


### PR DESCRIPTION
Make libhoney usable with the defaults if you forget to call `Init()` with a config (and if you use a `Builder` directly instead).

Also beefs up the tests and makes sure that blocking behavior is verified and respected.