### PR TITLE
Send batches to new batch endpoint, deserialize batched responses

### DIFF
--- a/examples/read_json_log.go
+++ b/examples/read_json_log.go
@@ -77,7 +77,7 @@ func main() {
 
 func readResponses(responses chan libhoney.Response) {
 	for r := range responses {
-		if r.StatusCode == 200 {
+		if r.StatusCode >= 200 && r.StatusCode < 300 {
 			id := r.Metadata.(string)
 			fmt.Printf("Successfully sent event %s to Honeycomb\n", id)
 		} else {

--- a/libhoney.go
+++ b/libhoney.go
@@ -23,7 +23,7 @@ import (
 const (
 	defaultSampleRate = 1
 	defaultAPIHost    = "https://api.honeycomb.io/"
-	version           = "1.1.2"
+	version           = "1.2.0"
 
 	// defaultmaxBatchSize how many events to collect in a batch
 	defaultmaxBatchSize = 50

--- a/libhoney.go
+++ b/libhoney.go
@@ -364,7 +364,8 @@ func NewEvent() *Event {
 }
 
 // AddField adds an individual metric to the event or builder on which it is
-// called.
+// called. Note that if you add a value that cannot be serialized to JSON (eg a
+// function or channel), the event will fail to send.
 func (f *fieldHolder) AddField(key string, val interface{}) {
 	f.lock.Lock()
 	defer f.lock.Unlock()

--- a/libhoney.go
+++ b/libhoney.go
@@ -4,11 +4,6 @@
 
 package libhoney
 
-// breaks honeytail tests because leash_test.go assumes all sorts of stuff about
-// how libhoney is going to send requests (eg URL, headers, etc.). Clearly the
-// fault is with honeytail, but we should fix them before (or when) landing
-// this.
-
 import (
 	"bytes"
 	"encoding/json"

--- a/libhoney.go
+++ b/libhoney.go
@@ -4,6 +4,11 @@
 
 package libhoney
 
+// breaks honeytail tests because leash_test.go assumes all sorts of stuff about
+// how libhoney is going to send requests (eg URL, headers, etc.). Clearly the
+// fault is with honeytail, but we should fix them before (or when) landing
+// this.
+
 import (
 	"bytes"
 	"encoding/json"
@@ -59,7 +64,7 @@ var (
 
 // UserAgentAddition is a variable set at compile time via -ldflags to allow you
 // to augment the "User-Agent" header that libhoney sends along with each event.
-// The default User-Agent is "libhoney-go/1.1.1". If you set this variable, its
+// The default User-Agent is "libhoney-go/<version>". If you set this variable, its
 // contents will be appended to the User-Agent string, separated by a space. The
 // expected format is product-name/version, eg "myapp/1.0"
 var UserAgentAddition string

--- a/libhoney.go
+++ b/libhoney.go
@@ -261,6 +261,7 @@ type dynamicField struct {
 //
 // Make sure to call Close() to flush buffers.
 func Init(config Config) error {
+	rand.Seed(time.Now().UnixNano())
 	// Default sample rate should be 1. 0 is invalid.
 	if config.SampleRate == 0 {
 		config.SampleRate = defaultSampleRate

--- a/libhoney_test.go
+++ b/libhoney_test.go
@@ -709,6 +709,20 @@ func TestChannelMembers(t *testing.T) {
 	testEquals(t, ev4.data["D"], 2)
 }
 
+func TestEventMarshal(t *testing.T) {
+	e := Event{SampleRate: 1}
+	e.data = map[string]interface{}{"a": 1}
+	b, err := json.Marshal(e)
+	testOK(t, err)
+	testEquals(t, string(b), `{"data":{"a":1}}`)
+
+	e.Timestamp = time.Unix(1476309645, 0).UTC()
+	e.SampleRate = 5
+	b, err = json.Marshal(e)
+	testOK(t, err)
+	testEquals(t, string(b), `{"data":{"a":1},"samplerate":5,"time":"2016-10-12T22:00:45Z"}`)
+}
+
 //
 //  Examples
 //

--- a/response.go
+++ b/response.go
@@ -7,10 +7,10 @@ import (
 )
 
 // Response is a record of an event sent. It includes information about sending
-// the event - how long it took, whether it succeeded, and so on. It also has
-// a metadata field that is just a pass through - you add it to an Event and
-// it will be on the Response that correlates with that Event. This allows you
-// to track specific events.
+// the event - how long it took, whether it succeeded, and so on. It also has a
+// metadata field that is just a pass through - populate an Event's Metadata
+// field and what you put there will be on the Response that corresponds to
+// that Event. This allows you to track specific events.
 type Response struct {
 
 	// Err contains any error returned by the httpClient on sending or an error

--- a/response.go
+++ b/response.go
@@ -1,6 +1,10 @@
 package libhoney
 
-import "time"
+import (
+	"encoding/json"
+	"errors"
+	"time"
+)
 
 // Response is a record of an event sent. It includes information about sending
 // the event - how long it took, whether it succeeded, and so on. It also has
@@ -29,4 +33,19 @@ type Response struct {
 	// Metadata is whatever content you put in the Metadata field of the event for
 	// which this is the response. It is passed through unmodified.
 	Metadata interface{}
+}
+
+func (r *Response) UnmarshalJSON(b []byte) error {
+	aux := struct {
+		Error  string
+		Status int
+	}{}
+	if err := json.Unmarshal(b, &aux); err != nil {
+		return err
+	}
+	r.StatusCode = aux.Status
+	if aux.Error != "" {
+		r.Err = errors.New(aux.Error)
+	}
+	return nil
 }

--- a/transmission.go
+++ b/transmission.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 	"net/url"
 	"path"
-	"strconv"
 	"strings"
 	"sync"
 	"time"

--- a/transmission.go
+++ b/transmission.go
@@ -192,7 +192,6 @@ func (b *batchAgg) Fire(notifier muster.Notifier) {
 		if len(encEvs) <= 2 {
 			continue
 		}
-		fmt.Printf("%d encoded events:\n%s\n", numEncoded, encEvs)
 		// get some attributes common to this entire batch up front
 		apiHost := events[0].APIHost
 		writeKey := events[0].WriteKey

--- a/transmission_test.go
+++ b/transmission_test.go
@@ -1,11 +1,12 @@
 package libhoney
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -70,13 +71,6 @@ func TestTxAdd(t *testing.T) {
 		"overflow error should have been pushed into channel")
 }
 
-type FakeBody struct{}
-
-func (f *FakeBody) Read(p []byte) (int, error) {
-	l := copy(p, []byte("foo"))
-	return l, io.EOF
-}
-
 type FakeRoundTripper struct {
 	req     *http.Request
 	reqBody string
@@ -91,59 +85,74 @@ func (f *FakeRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	return f.resp, f.respErr
 }
 
-func TestTxSendRequest(t *testing.T) {
+type testNotifier struct{}
+
+func (tn *testNotifier) Done() {}
+
+// test the mechanics of sending / receiving responses
+func TestTxSendSingle(t *testing.T) {
 	responses = make(chan Response, 1)
 	frt := &FakeRoundTripper{}
-	frt.resp = &http.Response{
-		StatusCode: 200,
-		Body:       ioutil.NopCloser(&FakeBody{}),
-	}
-
 	b := &batch{
 		httpClient:  &http.Client{Transport: frt},
 		testNower:   &fakeNower{},
 		testBlocker: &sync.WaitGroup{},
 	}
-
-	fhData := map[string]interface{}{
-		"foo": "bar",
+	reset := func(b *batch, frt *FakeRoundTripper, body string, err error) {
+		if body == "" {
+			frt.resp = nil
+		} else {
+			frt.resp = &http.Response{
+				StatusCode: 200,
+				Body:       ioutil.NopCloser(strings.NewReader(body)),
+			}
+		}
+		frt.respErr = err
+		b.events = nil
 	}
+
+	fhData := map[string]interface{}{"foo": "bar"}
 	e := &Event{
 		fieldHolder: fieldHolder{data: fhData},
 		SampleRate:  4,
 		APIHost:     "http://fakeHost:8080/",
 		WriteKey:    "written",
-		Dataset:     "settled",
+		Dataset:     "ds1",
 		Metadata:    "emmetta",
 	}
-	b.sendRequest(e)
-	testEquals(t, frt.req.URL.String(), "http://fakeHost:8080/1/events/settled")
+	reset(b, frt, `{"ds1":[{"status":202}]}`, nil)
+	b.Add(e)
+	b.Fire(&testNotifier{})
+	expectedURL := fmt.Sprintf("%s/1/batch", e.APIHost)
+	testEquals(t, frt.req.URL.String(), expectedURL)
 	versionedUserAgent := fmt.Sprintf("libhoney-go/%s", version)
 	testEquals(t, frt.req.Header.Get("User-Agent"), versionedUserAgent)
 	testEquals(t, frt.req.Header.Get("X-Honeycomb-Team"), e.WriteKey)
-	testEquals(t, frt.req.Header.Get("X-Honeycomb-SampleRate"), "4")
-	testEquals(t, frt.reqBody, "{\"foo\":\"bar\"}\n")
+	testEquals(t, frt.reqBody, `{"ds1":[{"data":{"foo":"bar"},"samplerate":4}]}`)
 
 	rsp := testGetResponse(t, responses)
 	testEquals(t, rsp.Duration, time.Second*10)
 	testEquals(t, rsp.Metadata, "emmetta")
-	testEquals(t, rsp.StatusCode, 200)
+	testEquals(t, rsp.StatusCode, 202)
 	testOK(t, rsp.Err)
 
 	// test UserAgentAddition
 	UserAgentAddition = "  fancyApp/3 "
 	expectedUserAgentAddition := "fancyApp/3"
 	longUserAgent := fmt.Sprintf("%s %s", versionedUserAgent, expectedUserAgentAddition)
-	b.sendRequest(e)
+	reset(b, frt, `{"ds1":[{"status":202}]}`, nil)
+	b.Add(e)
+	b.Fire(&testNotifier{})
 	testEquals(t, frt.req.Header.Get("User-Agent"), longUserAgent)
 	rsp = testGetResponse(t, responses)
-	testEquals(t, rsp.StatusCode, 200)
+	testEquals(t, rsp.StatusCode, 202)
 	testOK(t, rsp.Err)
+	UserAgentAddition = ""
 
 	// test unsuccessful send
-	frt.resp = nil
-	frt.respErr = errors.New("testing error handling")
-	b.sendRequest(e)
+	reset(b, frt, "", errors.New("testing error handling"))
+	b.Add(e)
+	b.Fire(&testNotifier{})
 	rsp = testGetResponse(t, responses)
 	testErr(t, rsp.Err)
 	testEquals(t, rsp.StatusCode, 0)
@@ -151,8 +160,10 @@ func TestTxSendRequest(t *testing.T) {
 
 	// test nonblocking response path is actually nonblocking, drops response
 	responses <- placeholder
+	reset(b, frt, "", errors.New("err"))
 	b.testBlocker.Add(1)
-	go b.sendRequest(e)
+	b.Add(e)
+	go b.Fire(&testNotifier{})
 	b.testBlocker.Wait() // triggered on drop
 	rsp = testGetResponse(t, responses)
 	testIsPlaceholderResponse(t, rsp,
@@ -160,10 +171,10 @@ func TestTxSendRequest(t *testing.T) {
 
 	// test blocking response path, error
 	b.blockOnResponses = true
-	frt.resp = nil
-	frt.respErr = errors.New("testing error handling")
+	reset(b, frt, "", errors.New("err"))
 	responses <- placeholder
-	go b.sendRequest(e)
+	b.Add(e)
+	go b.Fire(&testNotifier{})
 	rsp = testGetResponse(t, responses)
 	testIsPlaceholderResponse(t, rsp,
 		"should pull placeholder response off channel first")
@@ -173,19 +184,161 @@ func TestTxSendRequest(t *testing.T) {
 	testEquals(t, len(rsp.Body), 0)
 
 	// test blocking response path, no error
-	frt.resp = &http.Response{
-		StatusCode: 200,
-		Body:       ioutil.NopCloser(&FakeBody{}),
-	}
-	frt.respErr = nil
 	responses <- placeholder
-	go b.sendRequest(e)
+	reset(b, frt, `{"ds1":[{"status":202}]}`, nil)
+	b.Add(e)
+	go b.Fire(&testNotifier{})
 	rsp = testGetResponse(t, responses)
 	testIsPlaceholderResponse(t, rsp,
 		"should pull placeholder response off channel first")
 	rsp = testGetResponse(t, responses)
 	testEquals(t, rsp.Duration, time.Second*10)
 	testEquals(t, rsp.Metadata, "emmetta")
-	testEquals(t, rsp.StatusCode, 200)
+	testEquals(t, rsp.StatusCode, 202)
 	testOK(t, rsp.Err)
+}
+
+// test the details of handling batch behavior
+func TestTxSendBatch(t *testing.T) {
+	tsts := []struct {
+		in         []map[string]interface{} // datas
+		expReqBody string
+		response   string // JSON from server
+		expected   []Response
+	}{
+		{
+			[]map[string]interface{}{
+				{"a": 1},
+				{"b": 2, "bb": 22},
+				{"c": 3.1},
+			},
+			`{"ds1":[{"data":{"a":1}},{"data":{"b":2,"bb":22}},{"data":{"c":3.1}}]}`,
+			`{"ds1":[{"status":202},{"status":202},{"status":429,"error":"bratelimited"}]}`,
+			[]Response{
+				{StatusCode: 202},
+				{StatusCode: 202},
+				{Err: errors.New("bratelimited"), StatusCode: 429},
+			},
+		},
+		{
+			[]map[string]interface{}{
+				{"a": 1},
+				{"b": func() {}},
+				{"c": 3.1},
+			},
+			`{"ds1":[{"data":{"a":1}},{"data":{"c":3.1}}]}`,
+			`{"ds1":[{"status":202},{"status":202}]}`,
+			[]Response{ // specific order!
+				{Err: errors.New("unsupported type"), Metadata: "emmetta1"},
+				{StatusCode: 202, Metadata: "emmetta0"},
+				{StatusCode: 202, Metadata: "emmetta2"},
+			},
+		},
+	}
+
+	frt := &FakeRoundTripper{
+		resp: &http.Response{
+			StatusCode: 200,
+		},
+	}
+	b := &batch{
+		httpClient: &http.Client{Transport: frt},
+	}
+
+	for _, tt := range tsts {
+		responses = make(chan Response, len(tt.expected))
+		frt.resp.Body = ioutil.NopCloser(strings.NewReader(tt.response))
+		for i, data := range tt.in {
+			b.Add(&Event{
+				fieldHolder: fieldHolder{data: data},
+				APIHost:     "fakeHost",
+				WriteKey:    "written",
+				Dataset:     "ds1",
+				Metadata:    fmt.Sprint("emmetta", i),
+			})
+		}
+		b.Fire(&testNotifier{})
+		for _, expResp := range tt.expected {
+			resp := testGetResponse(t, responses)
+			testEquals(t, resp.StatusCode, expResp.StatusCode)
+			if expResp.Err != nil {
+				if !strings.Contains(resp.Err.Error(), expResp.Err.Error()) {
+					t.Errorf("expected error to contain '%s', got: '%s'", expResp.Err.Error(), resp.Err.Error())
+				}
+			} else {
+				testEquals(t, resp.Err, expResp.Err)
+			}
+		}
+	}
+}
+
+func TestBatchMarshal(t *testing.T) {
+	tsts := []struct {
+		in       map[string][]map[string]interface{}
+		expected string
+		errMsgs  []string
+	}{
+		{
+			map[string][]map[string]interface{}{
+				"alpha": {
+					{"a": 1},
+					{"b": func() {}},
+					{"c": 3},
+				},
+				"beta": {
+					{"d": make(chan string)},
+					{"e": 5},
+				},
+				"gamma": {
+					{"f": 6},
+				},
+			},
+			`{"alpha":[{"data":{"a":1}},{"data":{"c":3}}],"beta":[{"data":{"e":5}}],"gamma":[{"data":{"f":6}}]}`,
+			[]string{"MarshalJSON", "MarshalJSON"},
+		},
+		{ // shouldn't happen based on how muster works, but just in case
+			map[string][]map[string]interface{}{"nada": {}},
+			"{}",
+			nil,
+		},
+		{
+			map[string][]map[string]interface{}{
+				"nada": {
+					{"a": func() {}},
+					{"b": make(chan string)},
+				},
+				"zip": {
+					{"c": func() {}},
+				},
+			},
+			"{}",
+			[]string{"MarshalJSON", "MarshalJSON", "MarshalJSON"},
+		},
+	}
+
+	for _, tt := range tsts {
+		b := &batch{blockOnResponses: true}
+		for dName, datas := range tt.in {
+			for _, d := range datas {
+				b.Add(&Event{
+					Dataset: dName,
+					fieldHolder: fieldHolder{
+						data: d,
+					},
+				})
+			}
+		}
+		responses = make(chan Response, len(tt.errMsgs))
+
+		encoded, err := json.Marshal(b)
+		testOK(t, err)
+		testEquals(t, string(encoded), tt.expected)
+		for _, errMsg := range tt.errMsgs {
+			rsp := testGetResponse(t, responses)
+			testErr(t, rsp.Err)
+			if !strings.Contains(rsp.Err.Error(), errMsg) {
+				t.Errorf("expected json encoding error, got: %s", rsp.Err.Error())
+			}
+		}
+	}
 }

--- a/transmission_test.go
+++ b/transmission_test.go
@@ -116,7 +116,7 @@ func TestTxSendSingle(t *testing.T) {
 	e := &Event{
 		fieldHolder: fieldHolder{data: fhData},
 		SampleRate:  4,
-		APIHost:     "http://fakeHost:8080/",
+		APIHost:     "http://fakeHost:8080",
 		WriteKey:    "written",
 		Dataset:     "ds1",
 		Metadata:    "emmetta",

--- a/transmission_test.go
+++ b/transmission_test.go
@@ -260,7 +260,7 @@ func TestTxSendBatch(t *testing.T) {
 				APIHost:     "fakeHost",
 				WriteKey:    "written",
 				Dataset:     "ds1",
-				Metadata:    fmt.Sprint("emmetta", i),
+				Metadata:    fmt.Sprint("emmetta", i), // tracking insertion order
 			})
 		}
 		b.Fire(&testNotifier{})
@@ -281,7 +281,7 @@ func TestTxSendBatch(t *testing.T) {
 
 func TestBatchMarshal(t *testing.T) {
 	tsts := []struct {
-		in          map[string][]map[string]interface{}
+		in          map[string][]map[string]interface{} // map of {dataset to list of events}
 		niledEvents map[string][]bool
 		expected    string
 		errMsgs     []string


### PR DESCRIPTION
Depends on support coming to api.honeycomb.io for `/1/batch`, rather than queueing up and firing off individual events.

We don't do anything intelligent here yet around aligning batch size with API default rate limits, or constraining the size of a batch (and probably should). Feedback is totally welcome there (and there are some comments scattered throughout that are explicitly inviting feedback/comment.)

We do:
- gzip JSON payloads if possible
- Take [`facebookgo/muster`](github.com/facebookgo/muster)'s batches (which we were already using) and fire them off in batches to our API.
- Receive a batched set of responses (per patterns set forth by Google[1], Parse[2], and Dropbox[3]) and hand them down the `responses` channel individually
- Handle individual JSON errors separately (rather than a single unmarshallable field poisoning the whole batch)

1: https://developers.google.com/gmail/api/guides/batch#example
2: https://www.dropbox.com/developers/documentation/http/documentation#files-upload_session-finish_batch-check
3: https://parseplatform.github.io/docs/rest/guide/#batch-operations
