### PR TITLE
expose this tx.Stop/tx.Start function as ForceSendForTests so downstream tests can verify libhoney behavior.

### DIFF
--- a/libhoney.go
+++ b/libhoney.go
@@ -574,3 +574,8 @@ func (b *Builder) Clone() *Builder {
 	}
 	return newB
 }
+
+func ForceSendForTests() {
+	tx.Stop()  // flush unsent events
+	tx.Start() // reopen tx.muster channel
+}

--- a/libhoney_test.go
+++ b/libhoney_test.go
@@ -524,8 +524,7 @@ func TestSendTestTransport(t *testing.T) {
 	})
 
 	err := SendNow(map[string]interface{}{"foo": 3})
-	tx.Stop()  // flush unsent events
-	tx.Start() // reopen tx.muster channel
+	ForceSendForTests()
 	testOK(t, err)
 	testEquals(t, tr.invoked, true)
 }


### PR DESCRIPTION
There doesn't seem to be any other way to force events being routed through `Transport` so the resulting events can be checked.