### PR TITLE
Add SendPresampled for when the calling code handles sampling

### DIFF
--- a/transmission.go
+++ b/transmission.go
@@ -92,8 +92,9 @@ func (t *txDefaultClient) Add(ev *Event) {
 }
 
 type txTestClient struct {
-	Timestamps []time.Time
-	datas      [][]byte
+	Timestamps  []time.Time
+	datas       [][]byte
+	sampleRates []uint
 }
 
 func (t *txTestClient) Start() error {
@@ -113,6 +114,7 @@ func (t *txTestClient) Add(ev *Event) {
 		panic(err)
 	}
 	t.datas = append(t.datas, blob)
+	t.sampleRates = append(t.sampleRates, ev.SampleRate)
 }
 
 type batch struct {


### PR DESCRIPTION
In order to allow high volume code paths to avoid creating events as a method of sampling rather than creating them all and then dropping them before sending, add in a function to hand an event to libhoney that already represents the sampled content.