### PR TITLE
keep trailing slashes in APIHost from breaking things

### DIFF
--- a/transmission.go
+++ b/transmission.go
@@ -148,6 +148,14 @@ func (b *batch) sendRequest(e *Event) {
 		start = b.testNower.Now()
 	}
 	timestamp := e.Timestamp
+
+	url, err := url.Parse(e.APIHost)
+	if err != nil {
+		// TODO add logging or something to raise this error
+		sd.Increment("url_parse_errors")
+		return
+	}
+
 	blob, err := json.Marshal(e.data)
 	if err != nil {
 		// TODO add logging or something to raise this error
@@ -160,7 +168,6 @@ func (b *batch) sendRequest(e *Event) {
 		userAgent = fmt.Sprintf("%s %s", userAgent, strings.TrimSpace(UserAgentAddition))
 	}
 
-	url, err := url.Parse(e.APIHost)
 	url.Path = path.Join(url.Path, "/1/events", e.Dataset)
 	req, err := http.NewRequest("POST", url.String(), bytes.NewBuffer(blob))
 	req.Header.Set("User-Agent", userAgent)

--- a/transmission.go
+++ b/transmission.go
@@ -17,6 +17,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
+	"path"
 	"strconv"
 	"strings"
 	"sync"
@@ -158,8 +160,9 @@ func (b *batch) sendRequest(e *Event) {
 		userAgent = fmt.Sprintf("%s %s", userAgent, strings.TrimSpace(UserAgentAddition))
 	}
 
-	url := fmt.Sprintf("%s/1/events/%s", e.APIHost, e.Dataset)
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(blob))
+	url, err := url.Parse(e.APIHost)
+	url.Path = path.Join(url.Path, "/1/events", e.Dataset)
+	req, err := http.NewRequest("POST", url.String(), bytes.NewBuffer(blob))
 	req.Header.Set("User-Agent", userAgent)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Add("X-Honeycomb-Team", e.WriteKey)

--- a/transmission_test.go
+++ b/transmission_test.go
@@ -111,14 +111,13 @@ func TestTxSendRequest(t *testing.T) {
 	e := &Event{
 		fieldHolder: fieldHolder{data: fhData},
 		SampleRate:  4,
-		APIHost:     "fakeHost",
+		APIHost:     "http://fakeHost:8080/",
 		WriteKey:    "written",
 		Dataset:     "settled",
 		Metadata:    "emmetta",
 	}
 	b.sendRequest(e)
-	expectedURL := fmt.Sprintf("%s/1/events/%s", e.APIHost, e.Dataset)
-	testEquals(t, frt.req.URL.String(), expectedURL)
+	testEquals(t, frt.req.URL.String(), "http://fakeHost:8080/1/events/settled")
 	versionedUserAgent := fmt.Sprintf("libhoney-go/%s", version)
 	testEquals(t, frt.req.Header.Get("User-Agent"), versionedUserAgent)
 	testEquals(t, frt.req.Header.Get("X-Honeycomb-Team"), e.WriteKey)


### PR DESCRIPTION
use url.Parse + path.Join to build up the URL.

Previously, if APIHost was, e.g. `http://localhost:8081/`, we'd end up with a URL of `http://localhost:8081//1/events/<dataset>`.  This change fixes things such that we'll get `http://localhost:8081/1/events/<dataset>` instead.

Additionally, it'll also fail early if the URL isn't valid (instead of delaying it to the point where we consider it a `send_error`).