### PR TITLE
Eliminate double JSON serialization for efficiency.

### DIFF
--- a/libhoney.go
+++ b/libhoney.go
@@ -5,12 +5,14 @@
 package libhoney
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"math/rand"
 	"net/http"
 	"reflect"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -159,8 +161,62 @@ type Builder struct {
 }
 
 type fieldHolder struct {
-	data map[string]interface{}
+	data marshallableMap
 	lock sync.Mutex
+}
+
+// Wrapper type for custom JSON serialization: individual values that can't be
+// marshalled (or are null pointers) will be skipped, instead of causing
+// marshalling to raise an error.
+type marshallableMap map[string]interface{}
+
+func (m marshallableMap) MarshalJSON() ([]byte, error) {
+	keys := make([]string, len(m))
+	i := 0
+	for k, _ := range m {
+		keys[i] = k
+		i++
+	}
+	sort.Strings(keys)
+	out := bytes.NewBufferString("{")
+
+	first := true
+	for _, k := range keys {
+		b, ok := maybeMarshalValue(m[k])
+		if ok {
+			if first {
+				first = false
+			} else {
+				out.WriteByte(',')
+			}
+
+			out.WriteByte('"')
+			out.Write([]byte(k))
+			out.WriteByte('"')
+			out.WriteByte(':')
+			out.Write(b)
+		}
+	}
+	out.WriteByte('}')
+	return out.Bytes(), nil
+}
+
+func maybeMarshalValue(v interface{}) ([]byte, bool) {
+	if v == nil {
+		return nil, false
+	}
+	val := reflect.ValueOf(v)
+	kind := val.Type().Kind()
+	for _, ptrKind := range ptrKinds {
+		if kind == ptrKind && val.IsNil() {
+			return nil, false
+		}
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, false
+	}
+	return b, true
 }
 
 type dynamicField struct {
@@ -290,41 +346,7 @@ func NewEvent() *Event {
 func (f *fieldHolder) AddField(key string, val interface{}) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
-	// run a sanity check on data, transparently drop if it fails.
-	if validateData(val) {
-		f.data[key] = val
-	}
-}
-
-// validateData runs some checks on the data and returns false if it's bad data
-// and should be skipped
-func validateData(val interface{}) bool {
-	if val == nil {
-		return false
-	}
-	// if we can't json encode the value, we should skip it.
-	// TODO this is probably slow. Decide whether it's unacceptably slow.
-	_, err := json.Marshal(val)
-	if err != nil {
-		return false
-	}
-	return true
-}
-
-func validateValue(val reflect.Value) bool {
-	if val.Type().Kind() == reflect.Chan {
-		return false
-	}
-	kind := val.Type().Kind()
-	for _, ptrKind := range ptrKinds {
-		if kind == ptrKind && val.IsNil() {
-			return false
-		}
-	}
-	if validateData(val.Interface()) == false {
-		return false
-	}
-	return true
+	f.data[key] = val
 }
 
 // Add adds a complex data type to the event or builder on which it's called.
@@ -376,9 +398,7 @@ func (f *fieldHolder) addStruct(s interface{}) error {
 			fName = fieldInfo.Name
 		}
 
-		if validateValue(sVal.Field(i)) {
-			f.data[fName] = sVal.Field(i).Interface()
-		}
+		f.data[fName] = sVal.Field(i).Interface()
 	}
 	return nil
 }
@@ -403,9 +423,7 @@ func (f *fieldHolder) addMap(m interface{}) error {
 		default:
 			return fmt.Errorf("failed to add map: key type %s unaccepted", key.Type().Kind())
 		}
-		if validateValue(mVal.MapIndex(key)) {
-			f.data[keyStr] = mVal.MapIndex(key).Interface()
-		}
+		f.data[keyStr] = mVal.MapIndex(key).Interface()
 	}
 	return nil
 }

--- a/libhoney.go
+++ b/libhoney.go
@@ -173,7 +173,7 @@ type marshallableMap map[string]interface{}
 func (m marshallableMap) MarshalJSON() ([]byte, error) {
 	keys := make([]string, len(m))
 	i := 0
-	for k, _ := range m {
+	for k := range m {
 		keys[i] = k
 		i++
 	}

--- a/transmission.go
+++ b/transmission.go
@@ -172,7 +172,8 @@ func (b *batch) sendRequest(e *Event) {
 		return
 	}
 
-	blob, err := json.Marshal(e.data)
+	buf := new(bytes.Buffer)
+	err = json.NewEncoder(buf).Encode(e.data)
 	if err != nil {
 		// TODO add logging or something to raise this error
 		sd.Increment("json_marshal_errors")
@@ -186,7 +187,7 @@ func (b *batch) sendRequest(e *Event) {
 	}
 
 	url.Path = path.Join(url.Path, "/1/events", e.Dataset)
-	req, err := http.NewRequest("POST", url.String(), bytes.NewBuffer(blob))
+	req, err := http.NewRequest("POST", url.String(), buf)
 	req.Header.Set("User-Agent", userAgent)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Add("X-Honeycomb-Team", e.WriteKey)

--- a/transmission_test.go
+++ b/transmission_test.go
@@ -122,7 +122,7 @@ func TestTxSendRequest(t *testing.T) {
 	testEquals(t, frt.req.Header.Get("User-Agent"), versionedUserAgent)
 	testEquals(t, frt.req.Header.Get("X-Honeycomb-Team"), e.WriteKey)
 	testEquals(t, frt.req.Header.Get("X-Honeycomb-SampleRate"), "4")
-	testEquals(t, frt.reqBody, `{"foo":"bar"}`)
+	testEquals(t, frt.reqBody, "{\"foo\":\"bar\"}\n")
 
 	rsp := testGetResponse(t, responses)
 	testEquals(t, rsp.Duration, time.Second*10)


### PR DESCRIPTION
Previously, field data would be marshalled within a call to `Event.Add`, in
order to check if it could actually be marshalled. Any fields with
values that couldn't be marshalled (channels, maps with non-string keys, etc.)
would be quietly discarded.

This can be inefficient, since we have to marshal the event at transmission time
again anyways.

Instead, defer all marshalling to transmission time, but use custom marshalling
to ensure that any inadmissible values are quietly dropped, instead of causing
an error.

This likely won't make much difference for most users, but does improve
performance for high-volume use cases (it improves TCP agent throughput by 15-20%).