### PR TITLE
Seed `rand` in init() rather than libhoney.Init

### DIFF
--- a/libhoney.go
+++ b/libhoney.go
@@ -20,6 +20,10 @@ import (
 	"gopkg.in/alexcesaro/statsd.v2"
 )
 
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
 const (
 	defaultSampleRate = 1
 	defaultAPIHost    = "https://api.honeycomb.io/"
@@ -256,7 +260,6 @@ type dynamicField struct {
 //
 // Make sure to call Close() to flush buffers.
 func Init(config Config) error {
-	rand.Seed(time.Now().UnixNano())
 	// Default sample rate should be 1. 0 is invalid.
 	if config.SampleRate == 0 {
 		config.SampleRate = defaultSampleRate


### PR DESCRIPTION
Of course my very confident comment in https://github.com/honeycombio/libhoney-go/pull/3#discussion_r109018247 was slightly off (and outdated); `honeytail` calls `libhoney.Init` and starts event consumption in the same loop - so RNG seeding should happen once, only once, and not be dependent on the caller.