### PR TITLE
use marshallabelMap when encoding event data for batches

### DIFF
--- a/libhoney.go
+++ b/libhoney.go
@@ -159,9 +159,9 @@ func (e Event) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(struct {
-		Data       map[string]interface{} `json:"data"`
-		SampleRate uint                   `json:"samplerate,omitempty"`
-		Timestamp  *time.Time             `json:"time,omitempty"`
+		Data       marshallableMap `json:"data"`
+		SampleRate uint            `json:"samplerate,omitempty"`
+		Timestamp  *time.Time      `json:"time,omitempty"`
 	}{e.data, sampleRate, tPointer})
 }
 

--- a/transmission_test.go
+++ b/transmission_test.go
@@ -232,10 +232,10 @@ func TestTxSendBatchSingleDataset(t *testing.T) {
 				{"b": func() {}},
 				{"c": 3.1},
 			},
-			`[{"status":202},{"status":202}]`,
-			[]Response{ // specific order!
-				{Err: errors.New("unsupported type"), Metadata: "emmetta1"},
+			`[{"status":202},{"status":202},{"status":202}]`,
+			[]Response{
 				{StatusCode: 202, Metadata: "emmetta0"},
+				{StatusCode: 202, Metadata: "emmetta1"},
 				{StatusCode: 202, Metadata: "emmetta2"},
 			},
 		},


### PR DESCRIPTION
Turns out the batching PR changed data marshaling behavior in a subtle way.  Unmarshalable fields no longer get dropped individually, they cause the event itself to be dropped.