### PR TITLE
Make it possible to override event transmission for development and testing

### DIFF
--- a/libhoney.go
+++ b/libhoney.go
@@ -302,12 +302,11 @@ func Init(config Config) error {
 			blockOnResponses:     config.BlockOnResponse,
 			transport:            config.Transport,
 		}
-
-		if err := tx.Start(); err != nil {
-			return err
-		}
 	} else {
 		tx = config.Output
+	}
+	if err := tx.Start(); err != nil {
+		return err
 	}
 
 	sd, _ = statsd.New(statsd.Prefix("libhoney"))
@@ -482,9 +481,10 @@ func (f *fieldHolder) AddFunc(fn func() (string, interface{}, error)) error {
 	return nil
 }
 
+// Fields returns a reference to the map of fields that have been added to an
+// event. Caution: it is not safe to manipulate the returned map concurrently
+// with calls to AddField, Add or AddFunc.
 func (f *fieldHolder) Fields() map[string]interface{} {
-	f.lock.Lock()
-	defer f.lock.Unlock()
 	return f.data
 }
 


### PR DESCRIPTION
This patch adds an interface `Output`, for greater control over what
happens to events after `event.Send()` gets called in instrumented code paths.

An instance of `Output` can be passed in the global `Config` struct. The
existing `txDefaultClient` implements the `Output` interface, and remains the
default value if no particular output is specified.

We also provide two additional implementations, `MockOutput` and
`WriterOutput`, for unit-testing and for writing events to stdout,
respectively. We convert existing tests to use `MockOutput` instead of the
previous `txTestClient`. By exposing `MockOutput` as part of this library's
API, we make it easier for users to test their own instrumentation :)

One note: I don't quite love the name `Output`, but also am failing to come up
with a more compelling one. Any better ideas?