### PR TITLE
Improve error responses for top-level HTTP errors

### DIFF
--- a/transmission.go
+++ b/transmission.go
@@ -254,7 +254,11 @@ func (b *batchAgg) fireBatch(events []*Event) {
 
 	if resp.StatusCode != http.StatusOK {
 		sd.Increment("send_errors")
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			b.enqueueErrResponses(fmt.Errorf("Got HTTP error code but couldn't read response body: %v", err),
+				events, dur/time.Duration(numEncoded))
+		}
 		for _, ev := range events {
 			if ev != nil {
 				b.enqueueResponse(Response{

--- a/transmission.go
+++ b/transmission.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
@@ -239,17 +240,9 @@ func (b *batchAgg) fireBatch(events []*Event) {
 	// if the entire HTTP POST failed, send a failed response for every event
 	if err != nil {
 		sd.Increment("send_errors")
-		for _, ev := range events {
-			// Pass the top-level send error down responses channel for each event
-			// that didn't already error during encoding
-			if ev != nil {
-				b.enqueueResponse(Response{
-					Duration: dur / time.Duration(numEncoded),
-					Metadata: ev.Metadata,
-					Err:      err,
-				})
-			}
-		}
+		// Pass the top-level send error down responses channel for each event
+		// that didn't already error during encoding
+		b.enqueueErrResponses(err, events, dur/time.Duration(numEncoded))
 		// the POST failed so we're done with this batch key's worth of events
 		return
 	}
@@ -259,21 +252,29 @@ func (b *batchAgg) fireBatch(events []*Event) {
 	sd.Count("messages_sent", numEncoded)
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		sd.Increment("send_errors")
+		body, _ := ioutil.ReadAll(resp.Body)
+		for _, ev := range events {
+			if ev != nil {
+				b.enqueueResponse(Response{
+					StatusCode: resp.StatusCode,
+					Body:       body,
+					Duration:   dur / time.Duration(numEncoded),
+					Metadata:   ev.Metadata,
+				})
+			}
+		}
+		return
+	}
+
 	// decode the responses
 	batchResponses := []Response{}
 	err = json.NewDecoder(resp.Body).Decode(&batchResponses)
 	if err != nil {
 		// if we can't decode the responses, just error out all of them
 		sd.Increment("response_decode_errors")
-		for _, ev := range events {
-			if ev != nil {
-				b.enqueueResponse(Response{
-					Duration: dur,
-					Metadata: ev.Metadata,
-					Err:      err,
-				})
-			}
-		}
+		b.enqueueErrResponses(err, events, dur/time.Duration(numEncoded))
 		return
 	}
 
@@ -327,6 +328,18 @@ func (b *batchAgg) encodeBatch(events []*Event) ([]byte, int) {
 	}
 	buf.WriteByte(']')
 	return buf.Bytes(), numEncoded
+}
+
+func (b *batchAgg) enqueueErrResponses(err error, events []*Event, duration time.Duration) {
+	for _, ev := range events {
+		if ev != nil {
+			b.enqueueResponse(Response{
+				Err:      err,
+				Duration: duration,
+				Metadata: ev.Metadata,
+			})
+		}
+	}
 }
 
 // buildReqReader returns an io.Reader and a boolean, indicating whether or not

--- a/transmission.go
+++ b/transmission.go
@@ -258,6 +258,7 @@ func (b *batchAgg) fireBatch(events []*Event) {
 		if err != nil {
 			b.enqueueErrResponses(fmt.Errorf("Got HTTP error code but couldn't read response body: %v", err),
 				events, dur/time.Duration(numEncoded))
+			return
 		}
 		for _, ev := range events {
 			if ev != nil {


### PR DESCRIPTION
Previously, when submitting event batches to the Honeycomb API, we'd always try
to unmarshal the server's response into a slice `[]*Response`.

This could lead to very confusing results in some cases. For example,
if you supplied a bad write key, the server would respond with
`{"error":"unknown Team key - check your credentials"}`. That can't be
unmarshalled into the type `[]*Response`, so instead the `Err` field on
responses would be populated with
```
json: cannot unmarshal object into Go value of type []libhoney.Response
```

To make that less cryptic, check the top-level HTTP response code before unmarshalling.
If that response code isn't 200, we set the status code and body from the
HTTP response on each individual `Response` that we put in the response queue.
That makes it a lot easier to figure out that events aren't being sent because
of, say, a write key misconfiguration.

Test plan: unit tests