### PR TITLE
Respect omitempty struct tag when adding structs to events

### DIFF
--- a/libhoney.go
+++ b/libhoney.go
@@ -475,7 +475,12 @@ func (f *fieldHolder) addStruct(s interface{}) error {
 			}
 			// slice off options
 			if idx := strings.Index(fTag, ","); idx != -1 {
+				options := fTag[idx:]
 				fTag = fTag[:idx]
+				if strings.Contains(options, "omitempty") && isEmptyValue(sVal.Field(i)) {
+					// skip empty values if omitempty option is set
+					continue
+				}
 			}
 			fName = fTag
 		} else {
@@ -700,4 +705,23 @@ func (b *Builder) Clone() *Builder {
 		newB.dynFields = append(newB.dynFields, dynFd)
 	}
 	return newB
+}
+
+// Helper lifted from Go stdlib encoding/json
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+	return false
 }

--- a/libhoney_test.go
+++ b/libhoney_test.go
@@ -101,7 +101,6 @@ func TestAddStruct(t *testing.T) {
 		F2: 5,
 		F3: 6,
 		F4: 7,
-		F5: 8,
 		h1: 9,
 		h2: []string{"a", "b"},
 		P2: intPtr,
@@ -114,8 +113,7 @@ func TestAddStruct(t *testing.T) {
 			"F1": "snth",
 			"F2": 5,
 			"P2": 0,
-			"effthree": 6,
-			"f5": 8
+			"effthree": 6
 		}`,
 		string(marshalled))
 }


### PR DESCRIPTION
This patch changes the behavior of

```
ev := libhoney.NewEvent()
ev.Add(struct {
    A string `json:"a,omitempty"`
}{})
ev.Send()
```

Previously, that would create the event `{"a": ""}`. Now it'll skip the
empty `a` key.

This is affecting the zipkin proxy; it's kinda esoteric, but this seems
like "more right" behavior for libhoney to me ¯\_(ツ)_/¯