### PR TITLE
prevent a panic when calling Close() without Init()

### DIFF
--- a/libhoney.go
+++ b/libhoney.go
@@ -30,7 +30,7 @@ func init() {
 const (
 	defaultSampleRate = 1
 	defaultAPIHost    = "https://api.honeycomb.io/"
-	version           = "1.5.0"
+	version           = "1.5.1"
 
 	// DefaultMaxBatchSize how many events to collect in a batch
 	DefaultMaxBatchSize = 50

--- a/libhoney.go
+++ b/libhoney.go
@@ -375,7 +375,9 @@ func Init(config Config) error {
 // Close waits for all in-flight messages to be sent. You should
 // call Close() before app termination.
 func Close() {
-	tx.Stop()
+	if tx != nil {
+		tx.Stop()
+	}
 	close(responses)
 }
 

--- a/libhoney_test.go
+++ b/libhoney_test.go
@@ -39,6 +39,17 @@ func TestLibhoney(t *testing.T) {
 	testEquals(t, cap(responses), 2*DefaultPendingWorkCapacity)
 }
 
+func TestCloseWithoutInit(t *testing.T) {
+	// before Init() is called, tx is an unpopulated nil interface
+	tx = nil
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("recover should not have caught anything: got %v", r)
+		}
+	}()
+	Close()
+}
+
 func TestNewEvent(t *testing.T) {
 	resetPackageVars()
 	conf := Config{


### PR DESCRIPTION
When using the `startstop` and something fails during startup, `Stop()` can get called even though we didn't successfully `Start()`. This causes libhoney to throw a panic because it's trying to close a transmission that hasn't yet been created, so it's trying to call a function on a nil interface. 

Even if we haven't run `Init()`, we shouldn't panic trying to run `Close()`, it's just rude. So if the transmission interface hasn't yet been set up right, let's just skip closing it.