### PR TITLE
add discard output implementation to make it easy to mute libhoney

### DIFF
--- a/libhoney.go
+++ b/libhoney.go
@@ -30,7 +30,7 @@ func init() {
 const (
 	defaultSampleRate = 1
 	defaultAPIHost    = "https://api.honeycomb.io/"
-	version           = "1.5.1"
+	version           = "1.5.2"
 
 	// DefaultMaxBatchSize how many events to collect in a batch
 	DefaultMaxBatchSize = 50

--- a/transmission.go
+++ b/transmission.go
@@ -364,6 +364,13 @@ func (w *WriterOutput) Add(ev *Event) {
 	w.W.Write(m)
 }
 
+// Discard implements the Output interface and drops all events.
+type Discard struct {
+	*WriterOutput
+}
+
+func (d *Discard) Add(ev *Event) {}
+
 // MockOutput implements the Output interface by retaining a slice of added
 // events, for use in unit tests.
 type MockOutput struct {


### PR DESCRIPTION
While the default Writer implementation of the Output interface is good for development, and the Mock implementation good for when you want to test what libhoney is doing, the Discard interface is there to mute libhoney when you are testing other things (that might trigger sending events) and you want to send them to `/dev/null`. 

This is often available in libraries as a `mute` option.