### PR TITLE
Add a Flush function

### DIFF
--- a/libhoney.go
+++ b/libhoney.go
@@ -381,6 +381,20 @@ func Close() {
 	close(responses)
 }
 
+// Flush closes and reopens the Output interface, ensuring events
+// are sent without waiting on the batch to be sent asyncronously.
+// Generally, it is more efficient to rely on asyncronous batches than to
+// call Flush, but certain scenarios may require Flush if asynchronous sends
+// are not guaranteed to run (i.e. running in AWS Lambda)
+// Flush is not thread safe - use it only when you are sure that no other
+// parts of your program are calling Send
+func Flush() {
+	if tx != nil {
+		tx.Stop()
+		tx.Start()
+	}
+}
+
 // SendNow is a shortcut to create an event, add data, and send the event.
 func SendNow(data interface{}) error {
 	ev := NewEvent()

--- a/libhoney_test.go
+++ b/libhoney_test.go
@@ -845,3 +845,42 @@ func ExampleAddDynamicField() {
 	AddDynamicField("num_goroutines",
 		func() interface{} { return runtime.NumGoroutine() })
 }
+
+func BenchmarkInit(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		Init(Config{
+			WriteKey:   "aoeu",
+			Dataset:    "oeui",
+			SampleRate: 1,
+			APIHost:    "http://localhost:8081/",
+			Output:     &MockOutput{},
+		})
+		// create an event, add fields
+		ev := NewEvent()
+		ev.AddField("duration_ms", 153.12)
+		ev.AddField("method", "get")
+		// send the event
+		ev.Send()
+		Close()
+	}
+}
+
+func BenchmarkFlush(b *testing.B) {
+	Init(Config{
+		WriteKey:   "aoeu",
+		Dataset:    "oeui",
+		SampleRate: 1,
+		APIHost:    "http://localhost:8081/",
+		Output:     &MockOutput{},
+	})
+	for n := 0; n < b.N; n++ {
+		// create an event, add fields
+		ev := NewEvent()
+		ev.AddField("duration_ms", 153.12)
+		ev.AddField("method", "get")
+		// send the event
+		ev.Send()
+		Flush()
+	}
+	Close()
+}


### PR DESCRIPTION
When using libhoney-go in AWS lambda, I discovered that in some low-throughput scenarios, libhoney never gets a chance to send its unfilled batches. This seems to be due to the way AWS "freezes" the go container, preventing the asynchronous batch send from happening. This can be replicated by spinning up a lambda function, and only sending a trickle of events (something like once per minute). The honeycomb events never arrive. When the rate is increased, the container gets enough run time to send batches, but now there's potentially lost events.

One solution is to call libhoney.Init() and libhoney.Close() in the handler - to ensure events are always flushed before the handler exists - however, this seems to have a significant performance cost if the volume of events is high. Init does a lot more work than is necessary to flush the events.

Here I am adding a Flush method that only does a Stop/Start on the transmission Output interface. Benchmarks (assuming I did them right) seem to indicate a 400x improvement over doing repeated Init/Close calls.

```
$ go test -bench=. -benchtime=10s
goos: darwin
goarch: amd64
pkg: github.com/honeycombio/libhoney-go
BenchmarkInit-4    	   20000	   1003938 ns/op
BenchmarkFlush-4   	10000000	      2425 ns/op
PASS
ok  	github.com/honeycombio/libhoney-go	56.249s
```