### PR TITLE
Relax event content constraints when not sending events to Honeycomb

### DIFF
--- a/libhoney.go
+++ b/libhoney.go
@@ -30,7 +30,7 @@ func init() {
 const (
 	defaultSampleRate = 1
 	defaultAPIHost    = "https://api.honeycomb.io/"
-	version           = "1.5.2"
+	version           = "1.5.3"
 
 	// DefaultMaxBatchSize how many events to collect in a batch
 	DefaultMaxBatchSize = 50


### PR DESCRIPTION
When using output implementations other than the default (send to honeycomb) it doesn't matter if the event doesn't have a writekey or a dataset. If the event is just getting printed to STDOUT or discarded or used as a mock for testing, it's just fine to be missing those things, and makes setting up the test harness much easier.