### PR TITLE
better debugging through a logger

### DIFF
--- a/libhoney.go
+++ b/libhoney.go
@@ -592,7 +592,7 @@ func (f *fieldHolder) Fields() map[string]interface{} {
 // fields are specified in neither Config nor the Event, Send will return an
 // error.  Required fields are APIHost, WriteKey, and Dataset. Values specified
 // in an Event override Config.
-func (e *Event) Send() (err error) {
+func (e *Event) Send() error {
 	if shouldDrop(e.SampleRate) {
 		logger.Printf("dropping event due to sampling")
 		sd.Increment("sampled")

--- a/libhoney.go
+++ b/libhoney.go
@@ -30,7 +30,7 @@ func init() {
 const (
 	defaultSampleRate = 1
 	defaultAPIHost    = "https://api.honeycomb.io/"
-	version           = "1.7.0"
+	version           = "1.8.0"
 
 	// DefaultMaxBatchSize how many events to collect in a batch
 	DefaultMaxBatchSize = 50

--- a/log.go
+++ b/log.go
@@ -2,36 +2,36 @@ package libhoney
 
 import (
 	"fmt"
-	"time"
+	"log"
 )
 
 // Logger is used to log extra info within the SDK detailing what's happening.
 // You can set a logger during initialization. If you leave it unititialized, no
 // logging will happen. If you set it to the DefaultLogger, you'll get
 // timestamped lines sent to STDOUT. Pass in your own implementation of the
-// interface to send it in to your own logger.
+// interface to send it in to your own logger. An instance of the go package
+// log.Logger satisfies this interface.
 type Logger interface {
-	// Log accepts the same msg, args style as fmt.Printf().
-	Log(msg string, args ...interface{})
+	// Printf accepts the same msg, args style as fmt.Printf().
+	Printf(msg string, args ...interface{})
 }
 
 // DefaultLogger implements Logger and prints messages to stdout prepended by a
 // timestamp (RFC3339 formatted)
 type DefaultLogger struct{}
 
-// Log prints the message to stdout.
-func (d *DefaultLogger) Log(msg string, args ...interface{}) {
+// Printf prints the message to stdout.
+func (d *DefaultLogger) Printf(msg string, args ...interface{}) {
 	// use the same format as the python libhoney:
 	// '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 	// except for go's more friendly rfc3339nano rather than asctime
-	t := time.Now().Format(time.RFC3339Nano)
-	msg = fmt.Sprintf("%s - %s - %s - %s", t, "libhoney", "DEBUG", msg)
-	fmt.Printf(msg+"\n", args...)
+	msg = fmt.Sprintf("%s - %s - %s", "libhoney", "DEBUG", msg)
+	log.Printf(msg+"\n", args...)
 }
 
 type nullLogger struct{}
 
-// Log swallows messages
-func (n *nullLogger) Log(msg string, args ...interface{}) {
+// Printf swallows messages
+func (n *nullLogger) Printf(msg string, args ...interface{}) {
 	// nothing to see here.
 }

--- a/log.go
+++ b/log.go
@@ -1,0 +1,37 @@
+package libhoney
+
+import (
+	"fmt"
+	"time"
+)
+
+// Logger is used to log extra info within the SDK detailing what's happening.
+// You can set a logger during initialization. If you leave it unititialized, no
+// logging will happen. If you set it to the DefaultLogger, you'll get
+// timestamped lines sent to STDOUT. Pass in your own implementation of the
+// interface to send it in to your own logger.
+type Logger interface {
+	// Log accepts the same msg, args style as fmt.Printf().
+	Log(msg string, args ...interface{})
+}
+
+// DefaultLogger implements Logger and prints messages to stdout prepended by a
+// timestamp (RFC3339 formatted)
+type DefaultLogger struct{}
+
+// Log prints the message to stdout.
+func (d *DefaultLogger) Log(msg string, args ...interface{}) {
+	// use the same format as the python libhoney:
+	// '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+	// except for go's more friendly rfc3339nano rather than asctime
+	t := time.Now().Format(time.RFC3339Nano)
+	msg = fmt.Sprintf("%s - %s - %s - %s", t, "libhoney", "DEBUG", msg)
+	fmt.Printf(msg+"\n", args...)
+}
+
+type nullLogger struct{}
+
+// Log swallows messages
+func (n *nullLogger) Log(msg string, args ...interface{}) {
+	// nothing to see here.
+}

--- a/response.go
+++ b/response.go
@@ -49,3 +49,20 @@ func (r *Response) UnmarshalJSON(b []byte) error {
 	}
 	return nil
 }
+
+// writeToResponse adds the response to the response queue. Returns true if it
+// dropped the response because it's set to not block on the queue being full
+// and the queue was full.
+func writeToResponse(resp Response, block bool) (dropped bool) {
+	logger.Log("got response code %d, error %s, and body %s", resp.StatusCode, resp.Err, string(resp.Body))
+	if block {
+		responses <- resp
+	} else {
+		select {
+		case responses <- resp:
+		default:
+			return true
+		}
+	}
+	return false
+}

--- a/response.go
+++ b/response.go
@@ -54,7 +54,7 @@ func (r *Response) UnmarshalJSON(b []byte) error {
 // dropped the response because it's set to not block on the queue being full
 // and the queue was full.
 func writeToResponse(resp Response, block bool) (dropped bool) {
-	logger.Log("got response code %d, error %s, and body %s", resp.StatusCode, resp.Err, string(resp.Body))
+	logger.Printf("got response code %d, error %s, and body %s", resp.StatusCode, resp.Err, string(resp.Body))
 	if block {
 		responses <- resp
 	} else {

--- a/transmission.go
+++ b/transmission.go
@@ -51,7 +51,7 @@ type txDefaultClient struct {
 }
 
 func (t *txDefaultClient) Start() error {
-	logger.Log("default transmission starting")
+	logger.Printf("default transmission starting")
 	t.muster.MaxBatchSize = t.maxBatchSize
 	t.muster.BatchTimeout = t.batchTimeout
 	t.muster.MaxConcurrentBatches = t.maxConcurrentBatches
@@ -67,12 +67,12 @@ func (t *txDefaultClient) Start() error {
 }
 
 func (t *txDefaultClient) Stop() error {
-	logger.Log("default transmission stopping")
+	logger.Printf("default transmission stopping")
 	return t.muster.Stop()
 }
 
 func (t *txDefaultClient) Add(ev *Event) {
-	logger.Log("adding event to transmission; queue length %d", len(t.muster.Work))
+	logger.Printf("adding event to transmission; queue length %d", len(t.muster.Work))
 	sd.Gauge("queue_length", len(t.muster.Work))
 	if t.blockOnSend {
 		t.muster.Work <- ev

--- a/transmission.go
+++ b/transmission.go
@@ -51,6 +51,7 @@ type txDefaultClient struct {
 }
 
 func (t *txDefaultClient) Start() error {
+	logger.Log("default transmission starting")
 	t.muster.MaxBatchSize = t.maxBatchSize
 	t.muster.BatchTimeout = t.batchTimeout
 	t.muster.MaxConcurrentBatches = t.maxConcurrentBatches
@@ -66,10 +67,12 @@ func (t *txDefaultClient) Start() error {
 }
 
 func (t *txDefaultClient) Stop() error {
+	logger.Log("default transmission stopping")
 	return t.muster.Stop()
 }
 
 func (t *txDefaultClient) Add(ev *Event) {
+	logger.Log("adding event to transmission; queue length %d", len(t.muster.Work))
 	sd.Gauge("queue_length", len(t.muster.Work))
 	if t.blockOnSend {
 		t.muster.Work <- ev
@@ -84,14 +87,7 @@ func (t *txDefaultClient) Add(ev *Event) {
 				Err:      errors.New("queue overflow"),
 				Metadata: ev.Metadata,
 			}
-			if t.blockOnResponses {
-				responses <- r
-			} else {
-				select {
-				case responses <- r:
-				default:
-				}
-			}
+			writeToResponse(r, t.blockOnResponses)
 		}
 	}
 }
@@ -127,15 +123,9 @@ func (b *batchAgg) Add(ev interface{}) {
 }
 
 func (b *batchAgg) enqueueResponse(resp Response) {
-	if b.blockOnResponses {
-		responses <- resp
-	} else {
-		select {
-		case responses <- resp:
-		default: // drop on the floor (and maybe notify tests)
-			if b.testBlocker != nil {
-				b.testBlocker.Done()
-			}
+	if writeToResponse(resp, b.blockOnResponses) {
+		if b.testBlocker != nil {
+			b.testBlocker.Done()
 		}
 	}
 }


### PR DESCRIPTION
To better enable people to debug their use of libhoney, this PR adds a Logger interface along with two default implementations - one to `stdout` and one to `/dev/null`. The user of libhoney is free to pass in their own logger, so long as it implements the `Log(string, ...interface{})` method.

The read json example is improved to highlight the `stdout` logger as well as actually succeed in going through the response queue due to adding a wait group. (previously it would exit before it could finish reading the responses.)
 
The logger is rather verbose, but I think that's ok for development. Here is some sample output:

```2018-09-21T16:46:57.437671909-07:00 - libhoney - DEBUG - adding event to transmission; queue length 0
2018-09-21T16:46:57.437678083-07:00 - libhoney - DEBUG - Send enqueued event with fields map[json_file_name:./example1.json json_line_number:5 read_json_log_version:0.0.1-example num_goroutines:3 timestamp problem:missing timestamp ingredient:eggs amount:3 step:5 comment:missing time field; this event will be sent with the current time.]; err=<nil>
2018-09-21T16:46:57.438657518-07:00 - libhoney - DEBUG - closing libhoney
2018-09-21T16:46:57.438663186-07:00 - libhoney - DEBUG - default transmission stopping
2018-09-21T16:46:57.995086199-07:00 - libhoney - DEBUG - got response code 202, error %!s(<nil>), and body
2018-09-21T16:45:59.056881115-07:00 - libhoney - DEBUG - got response code 401, error %!s(<nil>), and body {"error":"unknown API key - check your credentials"}
2018-09-21T16:45:59.056886224-07:00 - libhoney - DEBUG - got response code 401, error %!s(<nil>), and body {"error":"unknown API key - check your credentials"}
2018-09-21T16:46:57.995122157-07:00 - libhoney - DEBUG - got response code 202, error %!s(<nil>), and body
```