### PR TITLE
[rfc] [WIP] add skeleton of api similar to libhoney-js's

### DIFF
--- a/api/boards/client.go
+++ b/api/boards/client.go
@@ -1,0 +1,41 @@
+package boards
+
+import (
+	"github.com/honeycombio/libhoney-go/api"
+)
+
+const endpoint = "/1/boards"
+
+type Client struct {
+	api.TeamScopedClient
+}
+
+func (bc *Client) Create(board *Board) error {
+	return bc.TeamScopedClient.Create(endpoint, board)
+}
+
+func (bc *Client) List() ([]*Board, error) {
+	boards := []*Board{}
+	err := bc.TeamScopedClient.List(endpoint, &boards)
+	if err != nil {
+		return nil, err
+	}
+	return boards, nil
+}
+
+func (bc *Client) Get(id string) (*Board, error) {
+	board := Board{}
+	err := bc.TeamScopedClient.Get(endpoint, id, &board)
+	if err != nil {
+		return nil, err
+	}
+	return &board, nil
+}
+
+func (bc *Client) Update(board *Board) error {
+	return bc.TeamScopedClient.Update(endpoint, board.ID, board)
+}
+
+func (bc *Client) Delete(id string) error {
+	return bc.TeamScopedClient.Delete(endpoint, id)
+}

--- a/api/boards/types.go
+++ b/api/boards/types.go
@@ -1,0 +1,17 @@
+package boards
+
+import queriesAPI "github.com/honeycombio/libhoney-go/api/queries"
+
+type Board struct {
+	ID          string       `json:"id"`
+	Name        string       `json:"name"`
+	Description string       `json:"description"`
+	Queries     []BoardQuery `json:"queries"`
+}
+
+type BoardQuery struct {
+	Name        string           `json:"name"`
+	Description string           `json:"description"`
+	Dataset     string           `json:"dataset"`
+	Query       queriesAPI.Query `json:"query"`
+}

--- a/api/dataset_scoped_client.go
+++ b/api/dataset_scoped_client.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
+)
+
+type DatasetScopedClient struct {
+	APIHost    string
+	WriteKey   string
+	UserAgent  string
+	HTTPClient *http.Client
+}
+
+func (c *DatasetScopedClient) doRequest(method, endpoint, dataset, resourceID string, body io.Reader) (*http.Response, error) {
+	url, err := url.Parse(c.APIHost)
+	if err != nil {
+		return nil, err
+	}
+	url.Path = path.Join(url.Path, endpoint, dataset, resourceID)
+	req, err := http.NewRequest(method, url.String(), body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", c.UserAgent)
+	req.Header.Add("X-Honeycomb-Team", c.WriteKey)
+
+	return c.HTTPClient.Do(req)
+}
+
+func (c *DatasetScopedClient) Create(endpoint, dataset string, resource interface{}) error {
+	marshaledResource, err := json.Marshal(resource)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.doRequest("POST", endpoint, dataset, "", bytes.NewReader(marshaledResource))
+	return err
+}
+
+func (c *DatasetScopedClient) List(endpoint, dataset string, destSlice interface{}) error {
+	resp, err := c.doRequest("GET", endpoint, dataset, "", nil)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(bodyBytes, destSlice)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *DatasetScopedClient) Get(endpoint, dataset, id string, destResource interface{}) error {
+	resp, err := c.doRequest("GET", endpoint, dataset, id, nil)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(bodyBytes, destResource)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *DatasetScopedClient) Update(endpoint, dataset, id string, resource interface{}) error {
+	marshaledResource, err := json.Marshal(resource)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.doRequest("PUT", endpoint, dataset, id, bytes.NewReader(marshaledResource))
+	return err
+}
+
+func (c *DatasetScopedClient) Delete(endpoint, dataset, id string) error {
+	_, err := c.doRequest("DELETE", endpoint, dataset, id, nil)
+	return err
+}

--- a/api/markers/client.go
+++ b/api/markers/client.go
@@ -1,0 +1,41 @@
+package markers
+
+import (
+	"github.com/honeycombio/libhoney-go/api"
+)
+
+const endpoint = "/1/markers"
+
+type Client struct {
+	api.DatasetScopedClient
+}
+
+func (mc *Client) Create(dataset string, marker *Marker) error {
+	return mc.DatasetScopedClient.Create(endpoint, dataset, marker)
+}
+
+func (mc *Client) List(dataset string) ([]*Marker, error) {
+	markers := []*Marker{}
+	err := mc.DatasetScopedClient.List(endpoint, dataset, &markers)
+	if err != nil {
+		return nil, err
+	}
+	return markers, nil
+}
+
+func (mc *Client) Get(dataset, id string) (*Marker, error) {
+	marker := Marker{}
+	err := mc.DatasetScopedClient.Get(endpoint, dataset, id, &marker)
+	if err != nil {
+		return nil, err
+	}
+	return &marker, nil
+}
+
+func (mc *Client) Update(dataset string, marker *Marker) error {
+	return mc.DatasetScopedClient.Update(endpoint, dataset, marker.ID, marker)
+}
+
+func (mc *Client) Delete(dataset, id string) error {
+	return mc.DatasetScopedClient.Delete(endpoint, dataset, id)
+}

--- a/api/markers/types.go
+++ b/api/markers/types.go
@@ -1,0 +1,15 @@
+package markers
+
+type Marker struct {
+	ID string `json:"id"`
+	// StartTime unix timestamp truncates to seconds
+	StartTime int64 `json:"start_time"`
+	// EndTime unix timestamp truncates to seconds
+	EndTime int64 `json:"end_time"`
+	// Message is optional free-form text associated with the marker
+	Message string `json:"message"`
+	// Type is an optional marker identifier, eg 'deploy' or 'chef-run'
+	Type string `json:"type"`
+	// URL is an optional url associated with the marker
+	URL string `json:"url"`
+}

--- a/api/queries/types.go
+++ b/api/queries/types.go
@@ -1,0 +1,4 @@
+package queries
+
+type Query struct {
+}

--- a/api/team_scoped_client.go
+++ b/api/team_scoped_client.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
+)
+
+type TeamScopedClient struct {
+	APIHost    string
+	WriteKey   string
+	UserAgent  string
+	HTTPClient *http.Client
+}
+
+func (c *TeamScopedClient) doRequest(method, endpoint, resourceID string, body io.Reader) (*http.Response, error) {
+	url, err := url.Parse(c.APIHost)
+	if err != nil {
+		return nil, err
+	}
+	url.Path = path.Join(url.Path, endpoint, resourceID)
+	req, err := http.NewRequest(method, url.String(), body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", c.UserAgent)
+	req.Header.Add("X-Honeycomb-Team", c.WriteKey)
+
+	return c.HTTPClient.Do(req)
+}
+
+func (c *TeamScopedClient) Create(endpoint string, resource interface{}) error {
+	marshaledResource, err := json.Marshal(resource)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.doRequest("POST", endpoint, "", bytes.NewReader(marshaledResource))
+	return err
+}
+
+func (c *TeamScopedClient) List(endpoint string, destSlice interface{}) error {
+	resp, err := c.doRequest("GET", endpoint, "", nil)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(bodyBytes, destSlice)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *TeamScopedClient) Get(endpoint, id string, destResource interface{}) error {
+	resp, err := c.doRequest("GET", endpoint, id, nil)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(bodyBytes, destResource)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *TeamScopedClient) Update(endpoint, id string, resource interface{}) error {
+	marshaledResource, err := json.Marshal(resource)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.doRequest("PUT", endpoint, id, bytes.NewReader(marshaledResource))
+	return err
+}
+
+func (c *TeamScopedClient) Delete(endpoint, id string) error {
+	_, err := c.doRequest("DELETE", endpoint, id, nil)
+	return err
+}

--- a/api/triggers/client.go
+++ b/api/triggers/client.go
@@ -1,0 +1,39 @@
+package triggers
+
+import "github.com/honeycombio/libhoney-go/api"
+
+const endpoint = "/1/triggers"
+
+type Client struct {
+	api.DatasetScopedClient
+}
+
+func (tc *Client) Create(dataset string, trigger *Trigger) error {
+	return tc.DatasetScopedClient.Create(endpoint, dataset, trigger)
+}
+
+func (tc *Client) List(dataset string) ([]*Trigger, error) {
+	triggers := []*Trigger{}
+	err := tc.DatasetScopedClient.List(endpoint, dataset, &triggers)
+	if err != nil {
+		return nil, err
+	}
+	return triggers, nil
+}
+
+func (tc *Client) Get(dataset, id string) (*Trigger, error) {
+	trigger := Trigger{}
+	err := tc.DatasetScopedClient.Get(endpoint, dataset, id, &trigger)
+	if err != nil {
+		return nil, err
+	}
+	return &trigger, nil
+}
+
+func (tc *Client) Update(dataset string, trigger *Trigger) error {
+	return tc.DatasetScopedClient.Update(endpoint, dataset, trigger.ID, trigger)
+}
+
+func (tc *Client) Delete(dataset, id string) error {
+	return tc.DatasetScopedClient.Delete(endpoint, dataset, id)
+}

--- a/api/triggers/types.go
+++ b/api/triggers/types.go
@@ -1,0 +1,13 @@
+package triggers
+
+import queriesAPI "github.com/honeycombio/libhoney-go/api/queries"
+
+type Trigger struct {
+	ID          string           `json:"id"`
+	Name        string           `json:"name"`
+	Description string           `json:"description"`
+	Query       queriesAPI.Query `json:"query"`
+
+	// Threshold
+	// Recipients
+}

--- a/libhoney.go
+++ b/libhoney.go
@@ -21,6 +21,11 @@ import (
 	"time"
 
 	"gopkg.in/alexcesaro/statsd.v2"
+
+	"github.com/honeycombio/libhoney-go/api"
+	boardsAPI "github.com/honeycombio/libhoney-go/api/boards"
+	markersAPI "github.com/honeycombio/libhoney-go/api/markers"
+	triggersAPI "github.com/honeycombio/libhoney-go/api/triggers"
 )
 
 func init() {
@@ -52,6 +57,10 @@ var (
 	txOnce sync.Once
 
 	logger Logger = &nullLogger{}
+
+	boardsClient   *boardsAPI.Client
+	markersClient  *markersAPI.Client
+	triggersClient *triggersAPI.Client
 
 	blockOnResponses = false
 	sd, _            = statsd.New(statsd.Mute(true)) // init working default, to be overridden
@@ -384,6 +393,32 @@ func Init(config Config) error {
 		dynFields:  make([]dynamicField, 0, 0),
 		fieldHolder: fieldHolder{
 			data: make(map[string]interface{}),
+		},
+	}
+
+	apiClient := &http.Client{}
+	boardsClient = &boardsAPI.Client{
+		TeamScopedClient: api.TeamScopedClient{
+			APIHost:    config.APIHost,
+			WriteKey:   config.WriteKey,
+			UserAgent:  UserAgentAddition,
+			HTTPClient: apiClient,
+		},
+	}
+	markersClient = &markersAPI.Client{
+		DatasetScopedClient: api.DatasetScopedClient{
+			APIHost:    config.APIHost,
+			WriteKey:   config.WriteKey,
+			UserAgent:  UserAgentAddition,
+			HTTPClient: apiClient,
+		},
+	}
+	triggersClient = &triggersAPI.Client{
+		DatasetScopedClient: api.DatasetScopedClient{
+			APIHost:    config.APIHost,
+			WriteKey:   config.WriteKey,
+			UserAgent:  UserAgentAddition,
+			HTTPClient: apiClient,
 		},
 	}
 
@@ -763,4 +798,16 @@ func isEmptyValue(v reflect.Value) bool {
 		return v.IsNil()
 	}
 	return false
+}
+
+func Markers() *markersAPI.Client {
+	return markersClient
+}
+
+func Boards() *boardsAPI.Client {
+	return boardsClient
+}
+
+func Triggers() *triggersAPI.Client {
+	return triggersClient
 }


### PR DESCRIPTION
similar Create/List/Get/Update/Delete api to what's in honeycombio/libhoney-js#29

The types are totally skeletons at the moment, but the `List` api for triggers/boards/markers works enough for this tiny example:

```
package main
  
import (
        "fmt"

        libhoney "github.com/honeycombio/libhoney-go"
)

func listMarkers() {
        markers, err := libhoney.Markers().List("dataset-name")
        if err != nil {
                panic(err.Error())
        }
        for _, m := range markers {
                fmt.Println(m.ID, m.Type, m.Message, m.URL)
        }
}

func listBoards() {
        boards, err := libhoney.Boards().List()
        if err != nil {
                panic(err.Error())
        }
        for _, b := range boards {
                fmt.Printf("%s %s (%d queries)\n", b.ID, b.Name, len(b.Queries))
        }
}

func listTriggers() {
        triggers, err := libhoney.Triggers().List("dataset-name")
        if err != nil {
                panic(err.Error())
        }
        for _, t := range triggers {
                fmt.Printf("%s %s\n", t.ID, t.Name)
        }
}

func main() {
        libhoney.Init(libhoney.Config{
                WriteKey: "....",
        })

        listMarkers()
        listBoards()
        listTriggers()
}
```