### PR TITLE
fix: Add a timeout to the HTTP client

### DIFF
--- a/transmission.go
+++ b/transmission.go
@@ -58,8 +58,11 @@ func (t *txDefaultClient) Start() error {
 	t.muster.PendingWorkCapacity = t.pendingWorkCapacity
 	t.muster.BatchMaker = func() muster.Batch {
 		return &batchAgg{
-			batches:          map[string][]*Event{},
-			httpClient:       &http.Client{Transport: t.transport},
+			batches: map[string][]*Event{},
+			httpClient: &http.Client{
+				Transport: t.transport,
+				Timeout:   10 * time.Second,
+			},
 			blockOnResponses: t.blockOnResponses,
 		}
 	}


### PR DESCRIPTION
The default Go HTTP client does not have a timeout set and should
not be used in production. This adds a reasonable, but probably
exccessive, ten second timeout to the event send.

Callers will block forever when the timeout is not set, so any
HoneyComb API downtime will result in the callers OOMing due to
unlimited goroutines.

Details about this problem are further explained here:
https://medium.com/@nate510/don-t-use-go-s-default-http-client-4804cb19f779