### PR TITLE
[events] Allow pre-serialized json.RawMessage as event data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 dist: trusty
 
 go:
-        - 1.6
+        - 1.11
 
 script:
         - go test ./... -race -v


### PR DESCRIPTION
In samproxy, we'd like to avoid unmarshaling/marshaling event field data if we don't have to. One way to do this is to allow libhoney Events to support `json.RawMessage` in lieu of its usual fieldholder data. Without being too intrusive on the existing API, we can do this by adding an optional DataRawMessage field and serializing using that if it's set.