### PR TITLE
[transmission] enable toggling of gzip compression in Honeycomb trans…

### DIFF
--- a/libhoney.go
+++ b/libhoney.go
@@ -33,7 +33,7 @@ const (
 	defaultSampleRate = 1
 	defaultAPIHost    = "https://api.honeycomb.io/"
 	defaultDataset    = "libhoney-go dataset"
-	version           = "1.9.0"
+	version           = "1.9.1"
 
 	// DefaultMaxBatchSize how many events to collect in a batch
 	DefaultMaxBatchSize = 50


### PR DESCRIPTION
…mission implementation

I'm adding this as a configuration option to the default transmitter, as gzip is an implementation detail of how we send payloads over HTTP.