### PR TITLE
an empty Honeycomb transmission should be valid

### DIFF
--- a/libhoney.go
+++ b/libhoney.go
@@ -33,7 +33,7 @@ const (
 	defaultSampleRate = 1
 	defaultAPIHost    = "https://api.honeycomb.io/"
 	defaultDataset    = "libhoney-go dataset"
-	version           = "1.9.1"
+	version           = "1.9.2"
 
 	// DefaultMaxBatchSize how many events to collect in a batch
 	DefaultMaxBatchSize = 50

--- a/transmission/transmission.go
+++ b/transmission/transmission.go
@@ -58,6 +58,9 @@ type Honeycomb struct {
 }
 
 func (h *Honeycomb) Start() error {
+	if h.Logger == nil {
+		h.Logger = &nullLogger{}
+	}
 	h.Logger.Printf("default transmission starting")
 	h.responses = make(chan Response, h.PendingWorkCapacity*2)
 	h.muster.MaxBatchSize = h.MaxBatchSize

--- a/transmission/transmission_test.go
+++ b/transmission/transmission_test.go
@@ -24,6 +24,18 @@ type errReader struct{}
 
 func (e errReader) Read(b []byte) (int, error) { return 0, errors.New("mystery read error!") }
 
+func TestEmptyHoneycombTransmission(t *testing.T) {
+	// All fields on the Honeycomb transmission are optional; an empty honeycomb
+	// transmission should work (if not very well because of zero length channels)
+	tx := &Honeycomb{}
+	tx.Start()
+	tx.Add(&Event{
+		APIKey:  "kiddly",
+		Dataset: "diddly",
+		APIHost: "doo",
+	})
+}
+
 func TestHnyTxAdd(t *testing.T) {
 	hnyTx := &Honeycomb{
 		Logger:  &nullLogger{},


### PR DESCRIPTION
previously it failed when the logger was a nil pointer.