### PR TITLE
fix panic when sending events without initializing libhoney

### DIFF
--- a/client.go
+++ b/client.go
@@ -135,7 +135,8 @@ func (c *Client) ensureBuilder() {
 	c.oneBuilder.Do(func() {
 		if c.builder == nil {
 			c.builder = &Builder{
-				dynFields: make([]dynamicField, 0, 0),
+				SampleRate: 1,
+				dynFields:  make([]dynamicField, 0, 0),
 				fieldHolder: fieldHolder{
 					data: make(map[string]interface{}),
 				},

--- a/client_test.go
+++ b/client_test.go
@@ -163,6 +163,23 @@ func TestAddSendRaces(t *testing.T) {
 	// fmt.Printf("after, event data is %v", ev.data)
 }
 
+// Expected to error, but not panic.
+func TestDefaultClient(t *testing.T) {
+	t.Parallel()
+
+	c := Client{}
+	e := c.NewEvent()
+	e.AddField("foo", "bar")
+	err := e.Send()
+	assert.Error(t, err)
+
+	b := c.NewBuilder()
+	e = b.NewEvent()
+	e.AddField("foo", "bar")
+	err = e.Send()
+	assert.Error(t, err)
+}
+
 func TestEnsureLoggerRaces(t *testing.T) {
 	t.Parallel()
 	c := Client{}

--- a/libhoney.go
+++ b/libhoney.go
@@ -798,6 +798,10 @@ func (e *Event) SendPresampled() (err error) {
 
 // returns true if the sample should be dropped
 func shouldDrop(rate uint) bool {
+	if rate <= 1 {
+		return false
+	}
+
 	return rand.Intn(int(rate)) != 0
 }
 

--- a/libhoney.go
+++ b/libhoney.go
@@ -33,7 +33,7 @@ const (
 	defaultSampleRate = 1
 	defaultAPIHost    = "https://api.honeycomb.io/"
 	defaultDataset    = "libhoney-go dataset"
-	version           = "1.9.2"
+	version           = "1.9.3"
 
 	// DefaultMaxBatchSize how many events to collect in a batch
 	DefaultMaxBatchSize = 50


### PR DESCRIPTION
If libhoney is not initialized, the default client has SampleRate of 0.