### PR TITLE
protect against the first event in a batch failing while others succeeed

### DIFF
--- a/libhoney.go
+++ b/libhoney.go
@@ -33,7 +33,7 @@ const (
 	defaultSampleRate = 1
 	defaultAPIHost    = "https://api.honeycomb.io/"
 	defaultDataset    = "libhoney-go dataset"
-	version           = "1.9.3"
+	version           = "1.9.4"
 
 	// DefaultMaxBatchSize how many events to collect in a batch
 	DefaultMaxBatchSize = 50

--- a/transmission/transmission.go
+++ b/transmission/transmission.go
@@ -246,10 +246,17 @@ func (b *batchAgg) fireBatch(events []*Event) {
 	if numEncoded == 0 {
 		return
 	}
-	// get some attributes common to this entire batch up front
-	apiHost := events[0].APIHost
-	writeKey := events[0].APIKey
-	dataset := events[0].Dataset
+	// get some attributes common to this entire batch up front off the first
+	// valid event (some may be nil)
+	var apiHost, writeKey, dataset string
+	for _, ev := range events {
+		if ev != nil {
+			apiHost = ev.APIHost
+			writeKey = ev.APIKey
+			dataset = ev.Dataset
+			break
+		}
+	}
 
 	// sigh. dislike
 	userAgent := fmt.Sprintf("libhoney-go/%s", Version)


### PR DESCRIPTION
When processing a batch, if all events fail to encode or the entire batch is too large, everything's fine. However, if specifically the first event in the batch is too large (or JSON fails to encode) but others are encoded just fine, then the batch processing code can panic when it tries to get the API host and other shared values off the first event in the batch (that is now `nil`).

This change walks the list of events until it finds the first valid event (and there is guaranteed to be a valid event because the number of encoded events is >0) and uses the shared values from that event.

The added test fails with the expected panic without the code change and passes with the change.