### PR TITLE
fix panic in event.Send if client not set

### DIFF
--- a/libhoney.go
+++ b/libhoney.go
@@ -33,7 +33,7 @@ const (
 	defaultSampleRate = 1
 	defaultAPIHost    = "https://api.honeycomb.io/"
 	defaultDataset    = "libhoney-go dataset"
-	version           = "1.9.4"
+	version           = "1.9.5"
 
 	// DefaultMaxBatchSize how many events to collect in a batch
 	DefaultMaxBatchSize = 50
@@ -723,6 +723,9 @@ func (e *Event) AddFunc(fn func() (string, interface{}, error)) error {
 // Once you Send an event, any addition calls to add data to that event will
 // return without doing anything. Once the event is sent, it becomes immutable.
 func (e *Event) Send() error {
+	if e.client == nil {
+		e.client = &Client{}
+	}
 	e.client.ensureLogger()
 	if shouldDrop(e.SampleRate) {
 		e.client.logger.Printf("dropping event due to sampling")


### PR DESCRIPTION
We ensure a client exists in `SendPresampled` but not `Send`, leading to panic if an event is initialized with a nil client.