### PR TITLE
retry once on send timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
     parameters:
       goversion:
         type: string
-        default: "11"
+        default: "12"
     working_directory: /go/src/github.com/honeycombio/libhoney-go
     docker:
       - image: circleci/golang:1.<< parameters.goversion >>
@@ -27,7 +27,7 @@ jobs:
     parameters:
       goversion:
         type: string
-        default: "11"
+        default: "12"
     executor:
       name: go
       goversion: "<< parameters.goversion >>"
@@ -46,10 +46,6 @@ workflows:
     jobs:
       - setup
       - watch:
-          requires:
-            - setup
-      - test_libhoney:
-          goversion: "8"
           requires:
             - setup
       - test_libhoney:

--- a/libhoney.go
+++ b/libhoney.go
@@ -33,7 +33,7 @@ const (
 	defaultSampleRate = 1
 	defaultAPIHost    = "https://api.honeycomb.io/"
 	defaultDataset    = "libhoney-go dataset"
-	version           = "1.11.0"
+	version           = "1.11.1"
 
 	// DefaultMaxBatchSize how many events to collect in a batch
 	DefaultMaxBatchSize = 50


### PR DESCRIPTION
Dropping events on the first http timeout seems like a bad idea. This is my best current explanation for the persistent broken span in retriever traces. Only one retry, because we don't want a thundering herd.

Unfortunately the http package neglects to use exported errors, or even an exported error interface, for these conditions, although they indirectly mention the Timeout() method in the docs.