### PR TITLE
replace gzip with zstd

### DIFF
--- a/libhoney.go
+++ b/libhoney.go
@@ -33,7 +33,7 @@ const (
 	defaultSampleRate = 1
 	defaultAPIHost    = "https://api.honeycomb.io/"
 	defaultDataset    = "libhoney-go dataset"
-	version           = "1.11.1"
+	version           = "1.12.0"
 
 	// DefaultMaxBatchSize how many events to collect in a batch
 	DefaultMaxBatchSize = 50

--- a/transmission/helpers_test.go
+++ b/transmission/helpers_test.go
@@ -2,6 +2,7 @@ package transmission
 
 import (
 	"fmt"
+	"math/rand"
 	"net/http"
 	"path/filepath"
 	"reflect"
@@ -102,4 +103,22 @@ func (f *fakeNower) Now() time.Time {
 	now := time.Unix(1277132645, 0).Add(time.Second * 10 * time.Duration(f.iter))
 	f.iter++
 	return now
+}
+
+func fakePayload(fields int) map[string]interface{} {
+	m := make(map[string]interface{}, fields)
+	for i := 0; i < fields; i++ {
+		k := randomString(10)
+		switch i % 4 {
+		case 0:
+			m[k] = randomString(20)
+		case 1:
+			m[k] = rand.Float64()
+		case 2:
+			m[k] = "POST"
+		case 3:
+			m[k] = []int{200, 201, 203, 401, 402, 404, 500}[rand.Int31n(6)]
+		}
+	}
+	return m
 }


### PR DESCRIPTION
These benchmark results are pretty compelling:
```
BenchmarkCompression/raw-4         	  200000	      6914 ns/op	      64 B/op	       2 allocs/op
BenchmarkCompression/zstd-4        	    1000	   1636007 ns/op	     251 B/op	       3 allocs/op
BenchmarkCompression/gzip-4        	     200	   8688857 ns/op	  975648 B/op	      27 allocs/op
```

Note the improvement isn't entirely up to zstd itself; I also dialed down the compression slightly, and added a buffer pool to avoid allocating a ton of heap for every compression. This last is a bit misleading since we're still allocating the uncompressed buffer each time, but that's out of scope here.