### PR TITLE
use newer orb version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  buildevents: honeycombio/buildevents@0.2.0
+  buildevents: honeycombio/buildevents@0.2.3
 
 executors:
   go:


### PR DESCRIPTION
the new version works in more executors. not super necessary, but may as well stay up to date.