### PR TITLE
add end to end test, benchmark

### DIFF
--- a/transmission/transmission.go
+++ b/transmission/transmission.go
@@ -427,7 +427,7 @@ func (b *batchAgg) fireBatch(events []*Event) {
 	var eIdx int
 	for _, resp := range batchResponses {
 		resp.Duration = dur / time.Duration(numEncoded)
-		for events[eIdx] == nil {
+		for eIdx < len(events) && events[eIdx] == nil {
 			fmt.Printf("incr, eIdx: %d, len(evs): %d\n", eIdx, len(events))
 			eIdx++
 		}


### PR DESCRIPTION
Simple top-level e2e test and benchmark, which I was hoping would shed light on our reported memory regression. It does not, but may be a useful case in the future.