### PR TITLE
Allow sending to multiple destinations via MultiSender

### DIFF
--- a/libhoney.go
+++ b/libhoney.go
@@ -119,9 +119,10 @@ type Config struct {
 
 	// Transmission allows you to override what happens to events after you call
 	// Send() on them. By default, events are asynchronously sent to the
-	// Honeycomb API. You can use the MockOutput included in this package in
+	// Honeycomb API. You can use the MockSender included in this package in
 	// unit tests, or use the transmission.WriterSender to write events to
-	// STDOUT or to a file when developing locally.
+	// STDOUT or to a file when developing locally. You can use
+	// transmission.MultiSender to send to more than one destination at once.
 	Transmission transmission.Sender
 
 	// Configuration for the underlying sender. It is safe (and recommended) to

--- a/transmission/multi.go
+++ b/transmission/multi.go
@@ -1,0 +1,72 @@
+package transmission
+
+import (
+	"errors"
+
+	"github.com/honeycombio/libhoney-go"
+)
+
+type MultiSender struct {
+	Senders []Sender
+}
+
+func NewStandardPlusStdout() *MultiSender {
+	return &MultiSender{
+		Senders: []Sender{
+			&Honeycomb{
+				MaxBatchSize:         libhoney.DefaultMaxBatchSize,
+				BatchTimeout:         libhoney.DefaultBatchTimeout,
+				MaxConcurrentBatches: libhoney.DefaultMaxConcurrentBatches,
+				PendingWorkCapacity:  libhoney.DefaultPendingWorkCapacity,
+				UserAgentAddition:    libhoney.UserAgentAddition,
+				Logger:               &libhoney.DefaultLogger{},
+			},
+			&WriterSender{},
+		},
+	}
+}
+
+// Add calls Add on every configured Sender
+func (s *MultiSender) Add(ev *Event) {
+	for _, tx := range s.Senders {
+		tx.Add(ev)
+	}
+}
+
+// Start calls Start on every configured Sender, aborting on the first error
+func (s *MultiSender) Start() error {
+	if len(s.Senders) == 0 {
+		return errors.New("no senders configured")
+	}
+	for _, tx := range s.Senders {
+		if err := tx.Start(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Stop calls Stop on every configured Sender, aborting on the first error
+func (s *MultiSender) Stop() error {
+	for _, tx := range s.Senders {
+		if err := tx.Stop(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Responses returns the response channel from the first Sender only
+func (s *MultiSender) TxResponses() chan Response {
+	return s.Senders[0].TxResponses()
+}
+
+// SendResponse calls SendResponse on every configured Sender
+func (s *MultiSender) SendResponse(resp Response) bool {
+	for _, tx := range s.Senders {
+		if ok := tx.SendResponse(resp); !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/transmission/multi_test.go
+++ b/transmission/multi_test.go
@@ -1,0 +1,67 @@
+package transmission
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMultiSenderStart(t *testing.T) {
+	// Errors with no transmissions configured
+	s := &MultiSender{}
+	err := s.Start()
+	assert.NotNil(t, err, "starting an empty multi should be an error")
+
+	// Convenience startup is valid
+	s = NewStandardPlusStdout()
+	err = s.Start()
+	assert.Nil(t, err, "the plus stdout sender should start without errors")
+}
+
+func TestMultiSender(t *testing.T) {
+	a := &MockSender{}
+	b := &MockSender{}
+	sender := MultiSender{
+		Senders: []Sender{a, b},
+	}
+
+	t.Run("Start", func(t *testing.T) {
+		err := sender.Start()
+		assert.Nil(t, err)
+		assert.Equal(t, 1, a.Started)
+		assert.Equal(t, 1, b.Started)
+	})
+
+	t.Run("Stop", func(t *testing.T) {
+		err := sender.Stop()
+		assert.Nil(t, err)
+		assert.Equal(t, 1, a.Stopped)
+		assert.Equal(t, 1, b.Stopped)
+	})
+
+	t.Run("Add", func(t *testing.T) {
+		ev := Event{
+			Timestamp:  time.Time{}.Add(time.Second),
+			SampleRate: 2,
+			Dataset:    "dataset",
+			Data:       map[string]interface{}{"key": "val"},
+		}
+
+		sender.Add(&ev)
+
+		assert.Len(t, a.Events(), 1)
+		assert.Equal(t, ev, *a.Events()[0])
+		assert.Len(t, b.Events(), 1)
+		assert.Equal(t, ev, *b.Events()[0])
+	})
+
+	t.Run("TxResponses takes the first one", func(t *testing.T) {
+		assert.Equal(t, a.TxResponses(), sender.TxResponses())
+		assert.NotEqual(t, b.TxResponses(), sender.TxResponses())
+	})
+
+	t.Run("SendResponse", func(t *testing.T) {
+		sender.SendResponse(Response{})
+	})
+}


### PR DESCRIPTION
We're building a service and trying to do trace-only, so to give ourselves a debugging fallback we're planning to enable stdout and honeycomb in production.