### PR TITLE
[transmission] simplify using non-default Honeycomb transmission

### DIFF
--- a/client.go
+++ b/client.go
@@ -82,15 +82,11 @@ func NewClient(conf ClientConfig) (*Client, error) {
 	c.ensureLogger()
 
 	if conf.Transmission == nil {
-		c.transmission = &transmission.Honeycomb{
-			MaxBatchSize:         DefaultMaxBatchSize,
-			BatchTimeout:         DefaultBatchTimeout,
-			MaxConcurrentBatches: DefaultMaxConcurrentBatches,
-			PendingWorkCapacity:  DefaultPendingWorkCapacity,
-			UserAgentAddition:    UserAgentAddition,
-			Logger:               c.logger,
-			Metrics:              sd,
-		}
+		t := transmission.NewDefaultTransmission()
+		t.UserAgentAddition = UserAgentAddition
+		t.Logger = c.logger
+		t.Metrics = sd
+		c.transmission = t
 	} else {
 		c.transmission = conf.Transmission
 	}


### PR DESCRIPTION
Because the main libhoney init and the transmission init share properties (back from before we exposed transmissions and clients quite so much) it's super easy to get a config that doesn't match what you intended.

We should make that harder by:
* deprecating settings in the libhoney init that should be set on a transmission, and make more complete the "if you want a non-default transmission, make your own"
* adding a NewDefaultTransmission() function so that it's easier to make your own with appropriate defaults and so on.

In this PR:

- deprecate BatchTimeout, MaxBatchSize, MaxConcurrentBatches, PendingWorkCapacity, BlockOnsend, and BlockOnResponse in the `libhoney.Config`. We'll still accept these values, but the docs will steer folks toward creating a `Transmission` object.
- We now provide a `NewDefaultTransmission` function to supply reasonable defaults when building your own Transmission.
- In the event of someone passing in a sparsely populated `transmission.Honeycomb` object, we inject reasonable defaults at `Init` time. This should make it easier to pass a `Transmission` object without setting every possible option
- Resolve conflicts between the `libhoney.Config` and `transmission.Honeycomb` object.

Hopefully this is more user-friendly (ultimate goal here is to make programmatic setting of proxy configs less of a headache).