### PR TITLE
fix deadlock condition and reduce zstd memory footprint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,3 +64,7 @@ workflows:
           goversion: "12"
           requires:
             - setup
+      - test_libhoney:
+          goversion: "13"
+          requires:
+            - setup

--- a/libhoney.go
+++ b/libhoney.go
@@ -762,8 +762,14 @@ func (e *Event) SendPresampled() (err error) {
 			e.client.logger.Printf("Send enqueued event: %+v", e)
 		}
 	}()
-	e.lock.RLock()
-	defer e.lock.RUnlock()
+
+	// Lock the sent bool before taking the event lock, to match the order in
+	// the Add methods.
+	e.sendLock.Lock()
+	defer e.sendLock.Unlock()
+
+	e.fieldHolder.lock.RLock()
+	defer e.fieldHolder.lock.RUnlock()
 	if len(e.data) == 0 {
 		return errors.New("No metrics added to event. Won't send empty event.")
 	}
@@ -788,9 +794,7 @@ func (e *Event) SendPresampled() (err error) {
 		return errors.New("No Dataset for Honeycomb. Can't send datasetless.")
 	}
 
-	// lock the sent bool and then mark the event as sent. No more changes!
-	e.sendLock.Lock()
-	defer e.sendLock.Unlock()
+	// Mark the event as sent, no more field changes will be applied.
 	e.sent = true
 
 	e.client.ensureTransmission()

--- a/transmission/transmission.go
+++ b/transmission/transmission.go
@@ -579,7 +579,10 @@ func init() {
 	var err error
 	zstdEncoder, err = zstd.NewWriter(
 		nil,
+		// Compression level 2 gives a good balance of speed and compression.
 		zstd.WithEncoderLevel(zstd.EncoderLevelFromZstd(2)),
+		// zstd allocates 2 * GOMAXPROCS * window size, so use a small window.
+		// Most honeycomb messages are smaller than this.
 		zstd.WithWindowSize(1<<16),
 	)
 	if err != nil {

--- a/transmission/transmission.go
+++ b/transmission/transmission.go
@@ -572,12 +572,16 @@ func (r *pooledReader) Close() error {
 }
 
 // Instantiating a new encoder is expensive, so use a global one.
-// The docs say EncodeAll() is concurrency-safe.
+// EncodeAll() is concurrency-safe.
 var zstdEncoder *zstd.Encoder
 
 func init() {
 	var err error
-	zstdEncoder, err = zstd.NewWriter(nil, zstd.WithEncoderLevel(zstd.EncoderLevelFromZstd(2)))
+	zstdEncoder, err = zstd.NewWriter(
+		nil,
+		zstd.WithEncoderLevel(zstd.EncoderLevelFromZstd(2)),
+		zstd.WithWindowSize(1<<16),
+	)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Fixes a deadlock occasionally tripped by TestAddSendRaces, and uses the new zstd WithWindowSize option to reduce the pre-allocated encoding buffer from 8MB per CPU to 128KB per CPU. With our typically small payloads this should have a negligible impact on compression ratio.