### PR TITLE
Fix data race on dynFields length in Builder.Clone

### DIFF
--- a/libhoney.go
+++ b/libhoney.go
@@ -884,7 +884,6 @@ func (b *Builder) Clone() *Builder {
 		Dataset:    b.Dataset,
 		SampleRate: b.SampleRate,
 		APIHost:    b.APIHost,
-		dynFields:  make([]dynamicField, 0, len(b.dynFields)),
 		client:     b.client,
 	}
 	newB.data = make(map[string]interface{})
@@ -896,9 +895,8 @@ func (b *Builder) Clone() *Builder {
 	// copy dynamic metric generators
 	b.dynFieldsLock.RLock()
 	defer b.dynFieldsLock.RUnlock()
-	for _, dynFd := range b.dynFields {
-		newB.dynFields = append(newB.dynFields, dynFd)
-	}
+	newB.dynFields = make([]dynamicField, len(b.dynFields))
+	copy(newB.dynFields, b.dynFields)
 	return newB
 }
 

--- a/libhoney_test.go
+++ b/libhoney_test.go
@@ -526,6 +526,32 @@ func TestBuilderStaticFields(t *testing.T) {
 	testEquals(t, ev4.data["floatF"], nil)
 }
 
+func TestBuilderDynFieldsCloneRace(t *testing.T) {
+	resetPackageVars()
+
+	b := NewBuilder()
+
+	const interations = 100
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < interations; i++ {
+			b.Clone()
+		}
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < interations; i++ {
+			b.AddDynamicField("dyn_field", nil)
+		}
+	}()
+
+	wg.Wait()
+}
+
 func TestOutputInterface(t *testing.T) {
 	resetPackageVars()
 	testTx := &MockOutput{}


### PR DESCRIPTION
Hi, this didn't impact me just happened to notice it while reading the source.

Consistently triggers the race detector for me at 100 iterations, didn't trigger at 10.

Thanks in advance for reviewing!

---

`Builder.Clone` was reading the length of `dynFields` without holding `dynFieldsLock`. This moves the read to be covered by the lock.