### PR TITLE
Use gopkg.in for vmihailenco/msgpack v4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,18 @@ module github.com/honeycombio/libhoney-go
 
 go 1.14
 
+// To keep libhoney-go working for modules and non-modules users while msgpack's
+// branch configuration doesn't meet Go modules guidelines, import paths now use
+// `gopkg.in`. This requires two module replacements:
+//   - the `github.com` line fixes the import paths in msgpack
+//   - the `gopkg.in` line fixes the import paths in libhoney-go
+// Astoundingly, `go get` actually resolves this apparent circular replacement,
+// and it survives roundtrips through `go get -u` and `go mod tidy`.
+replace (
+	github.com/vmihailenco/msgpack/v4 => gopkg.in/vmihailenco/msgpack.v4 v4.3.11
+	gopkg.in/vmihailenco/msgpack.v4 => github.com/vmihailenco/msgpack/v4 v4.3.11
+)
+
 require (
 	github.com/DataDog/zstd v1.4.4
 	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a // indirect
@@ -13,7 +25,8 @@ require (
 	github.com/golang/protobuf v1.3.5 // indirect
 	github.com/klauspost/compress v1.10.3
 	github.com/stretchr/testify v1.5.1
-	github.com/vmihailenco/msgpack/v4 v4.3.11
+	github.com/vmihailenco/msgpack/v4 v4.3.11 // indirect
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect
 	gopkg.in/alexcesaro/statsd.v2 v2.0.0
+	gopkg.in/vmihailenco/msgpack.v4 v4.3.11
 )

--- a/go.sum
+++ b/go.sum
@@ -34,7 +34,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/vmihailenco/msgpack/v4 v4.3.11 h1:Q47CePddpNGNhk4GCnAx9DDtASi2rasatE0cd26cZoE=
 github.com/vmihailenco/msgpack/v4 v4.3.11/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
@@ -58,5 +57,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/vmihailenco/msgpack.v4 v4.3.11 h1:tDgpWBCd0JraEhZB5oGg5T38z6Ch+xM55Evwa3gGbck=
+gopkg.in/vmihailenco/msgpack.v4 v4.3.11/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/transmission/event.go
+++ b/transmission/event.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/vmihailenco/msgpack/v4"
+	"gopkg.in/vmihailenco/msgpack.v4"
 )
 
 type Event struct {

--- a/transmission/event_test.go
+++ b/transmission/event_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/vmihailenco/msgpack/v4"
+	"gopkg.in/vmihailenco/msgpack.v4"
 )
 
 func TestEventMarshal(t *testing.T) {

--- a/transmission/response.go
+++ b/transmission/response.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/vmihailenco/msgpack/v4"
+	"gopkg.in/vmihailenco/msgpack.v4"
 )
 
 // Response is a record of an event sent. It includes information about sending

--- a/transmission/transmission.go
+++ b/transmission/transmission.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/facebookgo/muster"
 	"github.com/klauspost/compress/zstd"
-	"github.com/vmihailenco/msgpack/v4"
+	"gopkg.in/vmihailenco/msgpack.v4"
 )
 
 const (

--- a/transmission/transmission_test.go
+++ b/transmission/transmission_test.go
@@ -20,7 +20,7 @@ import (
 	// Use a different zstd library from the implementation, for more
 	// convincing testing.
 	"github.com/DataDog/zstd"
-	"github.com/vmihailenco/msgpack/v4"
+	"gopkg.in/vmihailenco/msgpack.v4"
 )
 
 var (


### PR DESCRIPTION
Fixes libhoney-go for non-modules users without changing module dependencies.

Actually resolves #77.