### PR TITLE
Make flush threadsafe

### DIFF
--- a/client.go
+++ b/client.go
@@ -161,14 +161,13 @@ func (c *Client) Close() {
 // Generally, it is more efficient to rely on asyncronous batches than to
 // call Flush, but certain scenarios may require Flush if asynchronous sends
 // are not guaranteed to run (i.e. running in AWS Lambda)
-// Flush is not thread safe - use it only when you are sure that no other
-// parts of your program are calling Send
 func (c *Client) Flush() {
 	c.ensureLogger()
 	c.logger.Printf("flushing libhoney client")
 	if c.transmission != nil {
-		c.transmission.Stop()
-		c.transmission.Start()
+		if err := c.transmission.Flush(); err != nil {
+			c.logger.Printf("unable to flush: %v", err)
+		}
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -95,6 +95,7 @@ type dirtySender struct{}
 
 func (ds *dirtySender) Start() error                            { return nil }
 func (ds *dirtySender) Stop() error                             { return nil }
+func (ds *dirtySender) Flush() error                            { return nil }
 func (ds *dirtySender) TxResponses() chan transmission.Response { return nil }
 func (ds *dirtySender) SendResponse(transmission.Response) bool { return true }
 func (ds *dirtySender) Add(ev *transmission.Event) {

--- a/libhoney.go
+++ b/libhoney.go
@@ -254,6 +254,13 @@ func (to *transitionOutput) Add(ev *transmission.Event) {
 	to.Output.Add(origEvent)
 }
 
+func (to *transitionOutput) Flush() error {
+	if err := to.Stop(); err != nil {
+		return err
+	}
+	return to.Stop()
+}
+
 func (to *transitionOutput) TxResponses() chan transmission.Response {
 	return to.responses
 }

--- a/transmission/mock.go
+++ b/transmission/mock.go
@@ -9,6 +9,7 @@ import (
 type MockSender struct {
 	Started          int
 	Stopped          int
+	Flushed          int
 	EventsCalled     int
 	events           []*Event
 	responses        chan Response
@@ -29,6 +30,10 @@ func (m *MockSender) Start() error {
 }
 func (m *MockSender) Stop() error {
 	m.Stopped += 1
+	return nil
+}
+func (m *MockSender) Flush() error {
+	m.Flushed += 1
 	return nil
 }
 

--- a/transmission/sender.go
+++ b/transmission/sender.go
@@ -11,8 +11,13 @@ type Sender interface {
 	Start() error
 
 	// Stop flushes any pending queues and blocks until everything in flight has
-	// been sent
+	// been sent. Once called, you cannot call Add unless Start has subsequently
+	// been called.
 	Stop() error
+
+	// Flush flushes any pending queues and blocks until everything in flight has
+	// been sent.
+	Flush() error
 
 	// Responses returns a channel that will contain a single Response for each
 	// Event added. Note that they may not be in the same order as they came in

--- a/transmission/transmission_test.go
+++ b/transmission/transmission_test.go
@@ -14,12 +14,14 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	// Use a different zstd library from the implementation, for more
 	// convincing testing.
 	"github.com/DataDog/zstd"
+	"github.com/facebookgo/muster"
 	"github.com/vmihailenco/msgpack/v4"
 )
 
@@ -57,6 +59,7 @@ func TestHnyTxAdd(t *testing.T) {
 	hnyTx := &Honeycomb{
 		Logger:  &nullLogger{},
 		Metrics: &nullMetrics{},
+		muster:  new(muster.Client),
 	}
 	hnyTx.muster.Work = make(chan interface{}, 1)
 	hnyTx.responses = make(chan Response, 1)
@@ -817,6 +820,111 @@ func TestFireBatchWithBrokenFirstEvent(t *testing.T) {
 
 		testEquals(t, len(b.overflowBatches), 0)
 		testEquals(t, trt.callCount, 1)
+	})
+}
+
+// fakeBatch is a muster.Batch implementation that let's us see what data gets
+// sent through a muster.Client. It also lets us delay the sending of the
+// batch through the block channel.
+type fakeBatch struct {
+	// block will prevent Fire from returning until block has been closed.
+	block <-chan struct{}
+	// receive from send to inspect the data that the muster.Client would have
+	// sent in this batch.
+	send  chan<- []interface{}
+	items []interface{}
+}
+
+func (fb *fakeBatch) Add(item interface{}) {
+	fb.items = append(fb.items, item)
+}
+
+func (fb *fakeBatch) Fire(notifier muster.Notifier) {
+	defer notifier.Done()
+	<-fb.block
+	fb.send <- fb.items
+}
+
+func TestHoneycombTransmissionFlush(t *testing.T) {
+	ev := &Event{
+		Metadata: "adder",
+	}
+
+	t.Run("Flush should send all data that has been Added", func(t *testing.T) {
+		// This test adds some data to the default Transmission implementation and
+		// flushes it. Then it checks to verify that the data that was added got
+		// sent.
+		w := new(Honeycomb)
+		w.MaxBatchSize = 1000
+		w.PendingWorkCapacity = 1
+		block := make(chan struct{})
+		close(block) // don't block the sending of this batch.
+		sendChan := make(chan []interface{})
+		b := &fakeBatch{
+			send:  sendChan,
+			block: block,
+		}
+
+		batchCount := int32(0)
+		w.batchMaker = func() muster.Batch {
+			t.Logf("creating batch %d", atomic.LoadInt32(&batchCount))
+			if atomic.CompareAndSwapInt32(&batchCount, 0, 1) {
+				return b
+			}
+			return &fakeBatch{}
+			// We want to be sure that the data we enqueue is flushed in the batch we
+			// expect. By not having s send channel on subsequent batches, we'll
+			// panic if we flush to other batches.
+		}
+
+		if err := w.Start(); err != nil {
+			t.Error("unable to start", err)
+		}
+		defer w.Stop()
+
+		w.Add(ev)
+		go func() {
+			if err := w.Flush(); err != nil {
+				t.Error("unable to flush", err)
+			}
+		}()
+
+		items := <-sendChan
+		testEquals(t, len(items), 1, "should be exactly one item")
+		testEquals(t, items[0], ev, "one item should be the event we added")
+	})
+
+	t.Run("Flush should not race or panic if Add is called while Flush is executing", func(t *testing.T) {
+		w := new(Honeycomb)
+		w.MaxBatchSize = 1000
+		block := make(chan struct{})
+		sendChan := make(chan []interface{}, 2)
+		b := &fakeBatch{
+			send:  sendChan,
+			block: block,
+		}
+
+		w.batchMaker = func() muster.Batch {
+			return b
+		}
+
+		if err := w.Start(); err != nil {
+			t.Error("unable to start", err)
+		}
+		defer func() {
+			<-block // reuse this block so that we don't race between adding and resource cleanup.
+			w.Stop()
+		}()
+		go func() {
+			w.Add(ev)
+			close(block)
+		}()
+		if err := w.Flush(); err != nil {
+			t.Error("unable to flush", err)
+		}
+		// This test doesn't assert anything. It just makes sure that you can call
+		// Add concurrently with Flush. Before we added locks, the race detector
+		// would detect a race here.
 	})
 }
 

--- a/transmission/writer.go
+++ b/transmission/writer.go
@@ -30,6 +30,8 @@ func (w *WriterSender) Start() error {
 
 func (w *WriterSender) Stop() error { return nil }
 
+func (w *WriterSender) Flush() error { return nil }
+
 func (w *WriterSender) Add(ev *Event) {
 	var m []byte
 	tPointer := &(ev.Timestamp)


### PR DESCRIPTION
~~First stab at addressing #80. The tests are heinous and appear to deadlock some of the time. I'll revisit those.~~

This addresses #80 by adding `Flush` to the `transmission.Sender` interface and implementing it in a threadsafe way in the implementations in `libhoney`. Additionally, `libhoney.Client.Flush` now uses `transmission.Sender.Flush` instead of calling `Stop` and `Start`.

The `watch` test appears to fail because of a missing circleci token. I'm not sure how to address that.