### PR TITLE
transmission: Export new WireEvent type

### DIFF
--- a/transmission/writer.go
+++ b/transmission/writer.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"sync"
-	"time"
 )
 
 // WriterSender implements the Sender interface by marshalling events to JSON
@@ -44,11 +43,16 @@ func (w *WriterSender) Add(ev *Event) {
 	}
 
 	m, _ = json.Marshal(struct {
-		Data       map[string]interface{} `json:"data"`
-		SampleRate uint                   `json:"samplerate,omitempty"`
-		Timestamp  *time.Time             `json:"time,omitempty"`
-		Dataset    string                 `json:"dataset,omitempty"`
-	}{ev.Data, sampleRate, tPointer, ev.Dataset})
+		WireEvent
+		Dataset string `json:"dataset,omitempty"`
+	}{
+		WireEvent: WireEvent{
+			Data:       ev.Data,
+			SampleRate: sampleRate,
+			Timestamp:  tPointer,
+		},
+		Dataset: ev.Dataset,
+	})
 	m = append(m, '\n')
 
 	w.Lock()


### PR DESCRIPTION
Which represents the event that Honeycomb's API accepts. I'd like to use
this in a mock/load testing server that takes Honeycomb batched events.
Having it exported would mean that I don't need to redefine it myself or
miss breaking changes. It could also be used by samproxy:

- https://github.com/honeycombio/samproxy/blob/3418d37765914ce531df96ccef0ecf3d0a5421e7/route/route.go#L494-L498