### PR TITLE
document potential failures if pendingWorkCapacity not specified

### DIFF
--- a/transmission/transmission.go
+++ b/transmission/transmission.go
@@ -49,6 +49,8 @@ type Honeycomb struct {
 	MaxConcurrentBatches uint
 
 	// how many events to allow to pile up
+	// if not specified, then the work channel becomes blocking
+	// and attempting to add an event to the queue can fail
 	PendingWorkCapacity uint
 
 	// whether to block or drop events when the queue fills


### PR DESCRIPTION
We encountered an issue with this in samproxy, documented here: https://github.com/honeycombio/samproxy/pull/107