### PR TITLE
Use deprecated documentation convention

### DIFF
--- a/libhoney.go
+++ b/libhoney.go
@@ -83,7 +83,8 @@ type Config struct {
 	APIKey string
 
 	// WriteKey is the deprecated name for the Honeycomb authentication token.
-	// Use APIKey instead. If both are set, APIKey takes precedence.
+	//
+	// Deprecated: Use APIKey instead. If both are set, APIKey takes precedence.
 	WriteKey string
 
 	// Dataset is the name of the Honeycomb dataset to which to send these events.
@@ -114,7 +115,9 @@ type Config struct {
 	BlockOnResponse bool
 
 	// Output is the deprecated method of manipulating how libhoney sends
-	// events. Please use Transmission instead.
+	// events.
+	//
+	// Deprecated: Please use Transmission instead.
 	Output Output
 
 	// Transmission allows you to override what happens to events after you call
@@ -132,7 +135,7 @@ type Config struct {
 	MaxConcurrentBatches uint          // how many batches can be inflight simultaneously. Overrides DefaultMaxConcurrentBatches.
 	PendingWorkCapacity  uint          // how many events to allow to pile up. Overrides DefaultPendingWorkCapacity
 
-	// Transport is deprecated and should not be used. To set the HTTP Transport
+	// Deprecated: Transport is deprecated and should not be used. To set the HTTP Transport
 	// set the Transport elements on the Transmission Sender instead.
 	Transport http.RoundTripper
 
@@ -223,9 +226,10 @@ func Init(conf Config) error {
 	return err
 }
 
-// Output is deprecated; use Transmission instead. OUtput was responsible for
-// handling events after Send() is called. Implementations of Add() must be safe
-// for concurrent calls.
+// Output was responsible for handling events after Send() is called. Implementations
+// of Add() must be safe for concurrent calls.
+//
+// Deprecated: Output is deprecated; use Transmission instead.
 type Output interface {
 	Add(ev *Event)
 	Start() error
@@ -277,8 +281,9 @@ func (to *transitionOutput) SendResponse(r transmission.Response) bool {
 	return false
 }
 
-// VerifyWriteKey is the deprecated call to validate a Honeycomb API key. Please
-// use VerifyAPIKey instead.
+// VerifyWriteKey is the deprecated call to validate a Honeycomb API key.
+//
+// Deprecated: Please use VerifyAPIKey instead.
 func VerifyWriteKey(config Config) (team string, err error) {
 	return VerifyAPIKey(config)
 }
@@ -331,7 +336,7 @@ Response body: %s`, resp.StatusCode, string(body))
 	return ret["team_slug"], nil
 }
 
-// Response is deprecated; please use transmission.Response instead.
+// Deprecated: Response is deprecated; please use transmission.Response instead.
 type Response struct {
 	transmission.Response
 }
@@ -474,13 +479,14 @@ func Flush() {
 	dc.Flush()
 }
 
-// SendNow is deprecated and may be removed in a future major release.
 // Contrary to its name, SendNow does not block and send data
 // immediately, but only enqueues to be sent asynchronously.
 // It is equivalent to:
 //   ev := libhoney.NewEvent()
 //   ev.Add(data)
 //   ev.Send()
+//
+// Deprecated: SendNow is deprecated and may be removed in a future major release.
 func SendNow(data interface{}) error {
 	dc.ensureLogger()
 	ev := NewEvent()
@@ -493,7 +499,9 @@ func SendNow(data interface{}) error {
 }
 
 // Responses returns the channel from which the caller can read the responses
-// to sent events. Responses is deprecated; please use TxResponses instead.
+// to sent events.
+//
+// Deprecated: Responses is deprecated; please use TxResponses instead.
 func Responses() chan Response {
 	oneResp.Do(func() {
 		if transitionResponses == nil {
@@ -840,13 +848,14 @@ func (b *Builder) AddDynamicField(name string, fn func() interface{}) error {
 	return nil
 }
 
-// SendNow is deprecated and may be removed in a future major release.
 // Contrary to its name, SendNow does not block and send data
 // immediately, but only enqueues to be sent asynchronously.
 // It is equivalent to:
 //   ev := builder.NewEvent()
 //   ev.Add(data)
 //   ev.Send()
+//
+// Deprecated: SendNow is deprecated and may be removed in a future major release.
 func (b *Builder) SendNow(data interface{}) error {
 	ev := b.NewEvent()
 	if err := ev.Add(data); err != nil {

--- a/mockoutput.go
+++ b/mockoutput.go
@@ -3,9 +3,10 @@ package libhoney
 import "github.com/honeycombio/libhoney-go/transmission"
 
 // MockOutput implements the Output interface and passes it along to the
-// transmission.MockSender. It is deprecated and you should use the
-// transmission.MockSender directly instead. It is provided here for backwards
-// compatibility and will be removed eventually.
+// transmission.MockSender.
+//
+// Deprecated: Please use the transmission.MockSender directly instead.
+// It is provided here for backwards compatibility and will be removed eventually.
 type MockOutput struct {
 	transmission.MockSender
 }

--- a/writer.go
+++ b/writer.go
@@ -5,9 +5,10 @@ import (
 )
 
 // WriterOutput implements the Output interface and passes it along to the
-// transmission.WriterSender. It is deprecated and you should use the
-// transmission.WriterSender directly instead. It is provided here for backwards
-// compatibility and will be removed eventually.
+// transmission.WriterSender.
+//
+// Deprecated: Please use the transmission.WriterSender directly instead.
+// It is provided here for backwards compatibility and will be removed eventually.
 type WriterOutput struct {
 	transmission.WriterSender
 }
@@ -25,10 +26,10 @@ func (w *WriterOutput) Add(ev *Event) {
 	w.WriterSender.Add(transEv)
 }
 
-// DiscardWriter implements the Output interface and drops all events. It is
-// deprecated and you should use the transmission.DiscardSender directly
-// instead. It is provided here for backwards compatibility and will be removed
-// eventually.
+// DiscardWriter implements the Output interface and drops all events.
+//
+// Deprecated: Please use the transmission.DiscardSender directly instead.
+// It is provided here for backwards compatibility and will be removed eventually.
 type DiscardOutput struct {
 	WriterOutput
 }


### PR DESCRIPTION
Go has a deprecated convention that can be used signal when a struct, field or type is no longer required - https://github.com/golang/go/wiki/Deprecated

This updated components where the description already used the `deprecated` and applies this convention.