### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*.{go},go.mod,go.sum]
+indent_style = tab
+indent_size = 8
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+indent_size = 4
+trim_trailing_whitespace = false


### PR DESCRIPTION
Adds a simple editor config for use with .go (eg tabs over spaces).