### PR TITLE
automate the creation of draft releases when project is tagged with a version number

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,20 @@ version: 2.1
 orbs:
   buildevents: honeycombio/buildevents@0.2.6
 
+matrix_goversions: &matrix_goversions
+  matrix:
+    parameters:
+      goversion: ["12", "13", "14"]
+
+# Default version of Go to use for Go steps
+default_goversion: &default_goversion "12"
+
 executors:
   go:
     parameters:
       goversion:
         type: string
-        default: "12"
+        default: *default_goversion
     working_directory: /home/circleci/go/src/github.com/honeycombio/libhoney-go
     docker:
       - image: cimg/go:1.<< parameters.goversion >>
@@ -25,11 +33,11 @@ jobs:
     steps:
       - buildevents/watch_build_and_finish
 
-  test_libhoney:
+  test:
     parameters:
       goversion:
         type: string
-        default: "12"
+        default: *default_goversion
     executor:
       name: go
       goversion: "<< parameters.goversion >>"
@@ -57,33 +65,18 @@ workflows:
       - watch:
           requires:
             - setup
-      - test_libhoney:
-          goversion: "12"
+      - test:
+          <<: *matrix_goversions
           requires:
             - setup
-      - test_libhoney:
-          goversion: "13"
-          requires:
-            - setup
-      - test_libhoney:
-          goversion: "14"
-          requires:
-            - setup
+
   build_libhoney:
     jobs:
       - setup
       - watch:
           requires:
             - setup
-      - test_libhoney:
-          goversion: "12"
-          requires:
-            - setup
-      - test_libhoney:
-          goversion: "13"
-          requires:
-            - setup
-      - test_libhoney:
-          goversion: "14"
+      - test:
+          <<: *matrix_goversions
           requires:
             - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,20 @@ version: 2.1
 orbs:
   buildevents: honeycombio/buildevents@0.2.6
 
+# enable a job when tag created (tag create is ignored by default)
+filters_always: &filters_always
+  filters:
+    tags:
+      only: /.*/
+
+# restrict a job to only run when a version tag (vNNNN) is created
+filters_publish: &filters_publish
+  filters:
+    tags:
+      only: /^v[0-9].*/
+    branches:
+      ignore: /.*/
+
 matrix_goversions: &matrix_goversions
   matrix:
     parameters:
@@ -22,6 +36,9 @@ executors:
       - image: cimg/go:1.<< parameters.goversion >>
         environment:
           GO111MODULE: "on"
+  github:
+    docker:
+      - image: cibuilds/github:0.13.0
 
 jobs:
   setup:
@@ -51,6 +68,15 @@ jobs:
                 field_name: go_version
                 field_value: << parameters.goversion >>
 
+  publish_github:
+    executor: github
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: "create draft release at GitHub"
+          command: ghr -draft -n ${CIRCLE_TAG} -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${CIRCLE_TAG}
+
 workflows:
   nightly:
     triggers:
@@ -72,11 +98,25 @@ workflows:
 
   build_libhoney:
     jobs:
-      - setup
+      - setup:
+          <<: *filters_always
       - watch:
+          <<: *filters_always
           requires:
             - setup
       - test:
+          <<: *filters_always
           <<: *matrix_goversions
           requires:
             - setup
+      - publish_github:
+          <<: *filters_publish
+          context: Honeycomb Secrets for Public Repos
+          filters:
+            tags:
+              only: /^v[0-9].*/
+            branches:
+              ignore: /.*/
+          requires:
+            - test
+


### PR DESCRIPTION
Also reorganizes the test steps to leverage a single declared list of Go versions and a default Go version to test.

A simple CI run from this branch using a prerelease version tag on its last commit:

### CI workflow viz

![CI workflow](https://user-images.githubusercontent.com/517302/104758552-9bdc0f80-572c-11eb-836a-eb4960221ea6.png)

### draft release created
![draft release created](https://user-images.githubusercontent.com/517302/104758573-a5657780-572c-11eb-8524-493eb1f2aed7.png)
