### PR TITLE
Prepare v1.15.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # libhoney Changelog
 
+## 1.14.1 2021-01-22
+
+NOTE: v1.15.1 may cause update warnings due to checksum error, please use v1.15.2 instead.
+
+### Maintenance
+
+- Add Github action to manage project labels (#110)
+- Automate the creation of draft releases when project is tagged (#109)
+
 ## 1.15.1 2021-01-14
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # libhoney Changelog
 
-## 1.14.1 2021-01-22
+## 1.15.1 2021-01-22
 
 NOTE: v1.15.1 may cause update warnings due to checksum error, please use v1.15.2 instead.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # libhoney Changelog
 
-## 1.15.1 2021-01-22
+## 1.15.2 2021-01-22
 
 NOTE: v1.15.1 may cause update warnings due to checksum error, please use v1.15.2 instead.
 

--- a/libhoney.go
+++ b/libhoney.go
@@ -33,7 +33,7 @@ const (
 	defaultSampleRate = 1
 	defaultAPIHost    = "https://api.honeycomb.io/"
 	defaultDataset    = "libhoney-go dataset"
-	version           = "1.15.1"
+	version           = "1.15.2"
 
 	// DefaultMaxBatchSize how many events to collect in a batch
 	DefaultMaxBatchSize = 50


### PR DESCRIPTION
Updates libhoney version to `1.15.2` and the change log with commits since last release.