### PR TITLE
Add more context to batch response parsing error

### DIFF
--- a/transmission/transmission.go
+++ b/transmission/transmission.go
@@ -480,7 +480,11 @@ func (b *batchAgg) fireBatch(events []*Event) {
 	if err != nil {
 		// if we can't decode the responses, just error out all of them
 		b.metrics.Increment("response_decode_errors")
-		b.enqueueErrResponses(err, events, dur/time.Duration(numEncoded))
+		b.enqueueErrResponses(fmt.Errorf(
+			"got OK HTTP response, but couldn't read response body: %v", err),
+			events,
+			dur/time.Duration(numEncoded),
+		)
 		return
 	}
 


### PR DESCRIPTION
By that point we know API response was OK, so it is nice to provide more context to consumers (specifically Refinery, which logs libhoney responses)