### PR TITLE
fix race condition on Honeycomb.Flush()

### DIFF
--- a/transmission/transmission.go
+++ b/transmission/transmission.go
@@ -137,13 +137,13 @@ func (h *Honeycomb) Flush() (err error) {
 	// the old one (which has a side-effect of flushing the data) and make a new
 	// one. We start the new one and swap it with the old one so that we minimize
 	// the time we hold the musterLock for.
-	m := h.muster
 	newMuster := h.createMuster()
 	err = newMuster.Start()
 	if err != nil {
 		return err
 	}
 	h.musterLock.Lock()
+	m := h.muster
 	h.muster = newMuster
 	h.musterLock.Unlock()
 	return m.Stop()


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- #139 

## Short description of the changes

- Eliminates the race condition on accessing the old muster by reading it only after acquiring the corresponding mutex.

