### PR TITLE
fix: ci secrets management

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,10 +20,10 @@ filters_publish: &filters_publish
 matrix_goversions: &matrix_goversions
   matrix:
     parameters:
-      goversion: ["12", "13", "14", "15", "16"]
+      goversion: ["12", "13", "14", "15", "16", "17"]
 
 # Default version of Go to use for Go steps
-default_goversion: &default_goversion "12"
+default_goversion: &default_goversion "16"
 
 executors:
   go:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,14 @@ workflows:
       - setup:
           <<: *filters_always
       - watch:
-          <<: *filters_always
+          context: Honeycomb Secrets for Public Repos
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore:
+                - /pull\/.*/
+                - /dependabot\/.*/
           requires:
             - setup
       - test:


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- noticed a failed build on outside PR, because buildevents `watch` needs secrets
- we are still using project environment variables instead of context for secrets

## Short description of the changes

- switch CI to use context for secret management
- allow outside contributor PRs and dependabot to bypass buildevents
- add go 17 to test matrix

