### PR TITLE
ci: remove buildevents from nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,9 +88,6 @@ workflows:
                 - main
     jobs:
       - setup
-      - watch:
-          requires:
-            - setup
       - test:
           <<: *matrix_goversions
           requires:


### PR DESCRIPTION
- schedule bot does not have enough secrets