### PR TITLE
update certs in old CI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,13 @@ jobs:
     steps:
       - buildevents/with_job_span:
           steps:
+            - when:
+                condition:
+                  equal: ["12", "<< parameters.goversion >>" ]
+                steps:
+                  - run:
+                      name: Update certs in old CI image
+                      command: sudo apt-get update && sudo apt-get install -y ca-certificates
             - checkout
             - run: go get -v -t -d ./...
             - run: go test -race -v ./...


### PR DESCRIPTION


## Which problem is this PR solving?

Fixes #146. As described on the issue, the certs in one of the signing chains for `gopkg.in` expired Sept 30, 2021. Clients need up-to-date CA certs to trust the current signing chain.

## Short description of the changes

This PR adds a conditional step to the test job to update the ca-certificates package within the running container when using the long-in-the-tooth Circle CI base image for Go 1.12.


