### PR TITLE
add test showing broken batch JSON marshaling

### DIFF
--- a/transmission/transmission_test.go
+++ b/transmission/transmission_test.go
@@ -689,12 +689,13 @@ func TestRenqueueEventsAfterOverflow(t *testing.T) {
 
 type testRoundTripper struct {
 	callCount int
+	body      []byte
 }
 
 func (t *testRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	t.callCount++
 
-	ioutil.ReadAll(r.Body)
+	t.body, _ = ioutil.ReadAll(r.Body)
 
 	return &http.Response{
 		StatusCode: 200,
@@ -823,6 +824,54 @@ func TestFireBatchWithBrokenFirstEvent(t *testing.T) {
 		testEquals(t, len(b.overflowBatches), 0)
 		testEquals(t, trt.callCount, 1)
 	})
+}
+
+// Ensure we can deal with batches with good events before and after a bad event
+// but only test the JSON path for now
+func TestFireBatchWithBrokenMiddleEvent(t *testing.T) {
+	trt := &testRoundTripper{}
+	b := &batchAgg{
+		httpClient: &http.Client{Transport: trt},
+		testNower:  &fakeNower{},
+		// testBlocker:           &sync.WaitGroup{},
+		responses:             make(chan Response, 1),
+		metrics:               &nullMetrics{},
+		disableCompression:    true,
+		enableMsgpackEncoding: false,
+	}
+
+	// add three events, a valid, a broken, and a valid.
+	b.Add(&Event{
+		Data:       map[string]interface{}{"all_good_data": "begin"},
+		SampleRate: 1,
+		APIHost:    "http://fakeHost:8080",
+		APIKey:     "written",
+		Dataset:    "ds1",
+		Metadata:   fmt.Sprintf("meta %d", 0),
+	})
+	b.Add(&Event{
+		Data:       map[string]interface{}{"reallyREALLYBigColumn": randomString(1024 * 1024)},
+		SampleRate: 1,
+		APIHost:    "http://fakeHost:8080",
+		APIKey:     "written",
+		Dataset:    "ds1",
+		Metadata:   fmt.Sprintf("meta %d", 1),
+	})
+	b.Add(&Event{
+		Data:       map[string]interface{}{"all_good_data": "end"},
+		SampleRate: 1,
+		APIHost:    "http://fakeHost:8080",
+		APIKey:     "written",
+		Dataset:    "ds1",
+		Metadata:   fmt.Sprintf("meta %d", 2),
+	})
+
+	b.Fire(&testNotifier{})
+	// b.testBlocker.Wait()
+	// testGetResponse(t, b.responses)
+	// testGetResponse(t, b.responses)
+	// the expected body will omit the overly large event and only have the beginning and ending event.
+	testEquals(t, string(trt.body), `[{"data":{"all_good_data":"begin"}},{"data":{"all_good_data":"end"}}]`)
 }
 
 // fakeBatch is a muster.Batch implementation that let's us see what data gets


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving? 

Occasionally we see events coming in via the batch endpoint that fail to unmarshal the JSON body. They complain about unexpected characters such as `,` or `]`. 

Examining the batch loop shows that if an event in th emiddle of a batch is rejected, ejither because it is too large or for another reason, the `continue` statement in the loop will leave the comma separating events in the JSON array despite not actually putting the event in the array. This leaves multiple commas in the final JSON. As an example, 

`[{"data":{"all_good_data":"begin"}},,{"data":{"all_good_data":"end"}}]` 

Note the two commas where the missing event should be. That is not valid JSON and will be rejected by the Honeycomb API servers.

## Short description of the changes

This change moves the comma insertion to after the event is successfully marshalled. If the iteration over events needs to skip an unmarshallable event, a comma will not be introduced for that event. 
