### PR TITLE
Prepare v1.15.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # libhoney Changelog
 
+## 1.15.6 2021-11-03
+
+### Fixed
+
+- Ensure valid JSON even when individual events in a batch can't be marshalled (#151)
+
+### Maintenance
+
+- empower apply-labels action to apply labels (#150)
+- add min go version to readme (#147)
+- update certs in old CI image (#148)
+- ci: remove buildevents from nightly (#144)
+- ci: secrets management (#142)
+
 ## 1.15.5 2021-09-27
 
 ### Fixed

--- a/libhoney.go
+++ b/libhoney.go
@@ -33,7 +33,7 @@ const (
 	defaultSampleRate = 1
 	defaultAPIHost    = "https://api.honeycomb.io/"
 	defaultDataset    = "libhoney-go dataset"
-	version           = "1.15.5"
+	version           = "1.15.6"
 
 	// DefaultMaxBatchSize how many events to collect in a batch
 	DefaultMaxBatchSize = 50


### PR DESCRIPTION
## Which problem is this PR solving?
Prepares the v1.15.6 release.

## Short description of the changes
- updates version in libhoney.go
- adds changelog entry

