### PR TITLE
fix: don't crash on stream aborts, always add content length

### DIFF
--- a/transmission/transmission_test.go
+++ b/transmission/transmission_test.go
@@ -124,7 +124,13 @@ type FakeRoundTripper struct {
 
 func (f *FakeRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	f.req = r
+	if r.ContentLength == 0 {
+		panic("Expected a content length for all POST payloads.")
+	}
 	bodyBytes, _ := ioutil.ReadAll(r.Body)
+	if r.ContentLength != int64(len(bodyBytes)) {
+		panic("Content length did not match number of read bytes.")
+	}
 	f.reqBody = string(bodyBytes)
 
 	// Honeycomb servers response to msgpack requests with msgpack responses,
@@ -486,7 +492,13 @@ func (f *FancyFakeRoundTripper) RoundTrip(r *http.Request) (*http.Response, erro
 		headerKeys := strings.Split(reqHeader, ",")
 		expectedURL, _ := url.Parse(fmt.Sprintf("%s/1/batch/%s", headerKeys[0], headerKeys[2]))
 		if r.Header.Get("X-Honeycomb-Team") == headerKeys[1] && r.URL.String() == expectedURL.String() {
+			if r.ContentLength == 0 {
+				panic("Expected a content length for all POST payloads.")
+			}
 			bodyBytes, _ := ioutil.ReadAll(r.Body)
+			if r.ContentLength != int64(len(bodyBytes)) {
+				panic("Content length did not match number of read bytes.")
+			}
 			f.reqBody = string(bodyBytes)
 
 			// make sure body is legitimately compressed json


### PR DESCRIPTION
## Which problem is this PR solving?

- Fixes crash from #154 caused by `Read()` after `Close()` -- tickled by https://go-review.googlesource.com/c/net/+/355491 (first introduced when Go x/net/http2 change backported to golang 1.17.3)
- Fixes missing Content-Length parameter due to underlying `bytes.Reader`s not being detected by Go standard library runtime type detection. https://cs.opensource.google/go/go/+/refs/tags/go1.17.5:src/net/http/request.go;l=890