### PR TITLE
Fix race condition in test and other test bugs

### DIFF
--- a/transmission/transmission.go
+++ b/transmission/transmission.go
@@ -173,8 +173,13 @@ func (h *Honeycomb) Add(ev *Event) {
 func (h *Honeycomb) tryAdd(ev *Event) bool {
 	h.musterLock.RLock()
 	defer h.musterLock.RUnlock()
-	h.Logger.Printf("adding event to transmission; queue length %d", len(h.muster.Work))
-	h.Metrics.Gauge("queue_length", len(h.muster.Work))
+
+	// Even though this queue is locked against changing h.Muster, the Work queue length
+	// could change due to actions on the worker side, so make sure we only measure it once.
+	qlen := len(h.muster.Work)
+	h.Logger.Printf("adding event to transmission; queue length %d", qlen)
+	h.Metrics.Gauge("queue_length", qlen)
+
 	if h.BlockOnSend {
 		h.muster.Work <- ev
 		return true

--- a/transmission/transmission_test.go
+++ b/transmission/transmission_test.go
@@ -924,10 +924,12 @@ func TestHoneycombTransmissionFlush(t *testing.T) {
 			if atomic.CompareAndSwapInt32(&batchCount, 0, 1) {
 				return b
 			}
-			return &fakeBatch{}
 			// We want to be sure that the data we enqueue is flushed in the batch we
-			// expect. By not having s send channel on subsequent batches, we'll
+			// expect. By having a closed send channel on subsequent batches, we'll
 			// panic if we flush to other batches.
+			sendChan2 := make(chan []interface{})
+			close(sendChan2)
+			return &fakeBatch{send: sendChan2}
 		}
 
 		if err := w.Start(); err != nil {
@@ -935,7 +937,12 @@ func TestHoneycombTransmissionFlush(t *testing.T) {
 		}
 		defer w.Stop()
 
+		// This call wants the Add to run first, and then make sure that the Flush doesn't lose the data.
+		// But on a fast machine, the Add might actually be interrupted by the Flush, and then correctly add the
+		// data to the *second* queue -- which is correct, but not what the test is looking for. So we'll
+		// give the Add a few msec to run first.
 		w.Add(ev)
+		time.Sleep(50 * time.Millisecond)
 		go func() {
 			if err := w.Flush(); err != nil {
 				t.Error("unable to flush", err)


### PR DESCRIPTION

## Which problem is this PR solving?
This fixes #161 and a couple of other issues discovered while debugging it. 

The immediate problem is that running the test under `-race` worked on my machine, while running without it hung forever. 

## Short description of the changes

- There was a race condition in the assumptions made by the test code -- the test code needed Add() to run before Flush() but on a fast machine, it might not finish in time. (It was confusing to debug because the test code is trying to induce potential race conditions!)
- There was an assertion in a test comment that a write to a nil channel would panic, but in fact, a write to a nil channel blocks forever. I changed the test to use a closed channel instead, which *will* panic if it occurs.
- Two successive statements attempted to log the same value (the length of a queue), but under concurrency they might not be the same value, so I added a temp var.

