### PR TITLE
Add environment & services support

### DIFF
--- a/libhoney.go
+++ b/libhoney.go
@@ -30,10 +30,11 @@ func init() {
 }
 
 const (
-	defaultSampleRate = 1
-	defaultAPIHost    = "https://api.honeycomb.io/"
-	defaultDataset    = "libhoney-go dataset"
-	version           = "2.0.0"
+	defaultSampleRate     = 1
+	defaultAPIHost        = "https://api.honeycomb.io/"
+	defaultClassicDataset = "libhoney-go dataset"
+	defaultDataset        = "unknown_service"
+	version               = "2.0.0"
 
 	// DefaultMaxBatchSize how many events to collect in a batch
 	DefaultMaxBatchSize = 50
@@ -146,6 +147,24 @@ type Config struct {
 	Logger Logger
 }
 
+func (c *Config) getDataset() string {
+	if c.isClassic() {
+		if strings.TrimSpace(c.Dataset) == "" {
+			return defaultClassicDataset
+		}
+		return c.Dataset
+	}
+	trimmedDataset := strings.TrimSpace(c.Dataset)
+	if trimmedDataset == "" {
+		return defaultDataset
+	}
+	return trimmedDataset
+}
+
+func (c *Config) isClassic() bool {
+	return c.APIKey == "" || len(c.APIKey) == 32
+}
+
 // Init is called on app initialization and passed a Config struct, which
 // configures default behavior. Use of package-level functions (e.g. SendNow())
 // require that WriteKey and Dataset are defined.
@@ -170,7 +189,7 @@ func Init(conf Config) error {
 	default:
 	}
 
-	clientConf.Dataset = conf.Dataset
+	clientConf.Dataset = conf.getDataset()
 	clientConf.SampleRate = conf.SampleRate
 	clientConf.APIHost = conf.APIHost
 

--- a/libhoney.go
+++ b/libhoney.go
@@ -157,7 +157,7 @@ func (c *Config) getDataset() string {
 	}
 	trimmedDataset := strings.TrimSpace(c.Dataset)
 	if trimmedDataset == "" {
-		fmt.Fprintln(os.Stderr, "WARN: Dataset is empty or whitespace, using default:", trimmedDataset)
+		fmt.Fprintln(os.Stderr, "WARN: Dataset is empty or whitespace, using default:", defaultDataset)
 		return defaultDataset
 	}
 	if c.Dataset != trimmedDataset {

--- a/libhoney.go
+++ b/libhoney.go
@@ -33,7 +33,7 @@ const (
 	defaultSampleRate     = 1
 	defaultAPIHost        = "https://api.honeycomb.io/"
 	defaultClassicDataset = "libhoney-go dataset"
-	defaultDataset        = "unknown_service"
+	defaultDataset        = "unknown_dataset"
 	version               = "2.0.0"
 
 	// DefaultMaxBatchSize how many events to collect in a batch

--- a/libhoney.go
+++ b/libhoney.go
@@ -13,6 +13,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"reflect"
 	"sort"
@@ -156,7 +157,11 @@ func (c *Config) getDataset() string {
 	}
 	trimmedDataset := strings.TrimSpace(c.Dataset)
 	if trimmedDataset == "" {
+		fmt.Fprintln(os.Stderr, "WARN: Dataset is empty or whitespace, using default:", trimmedDataset)
 		return defaultDataset
+	}
+	if c.Dataset != trimmedDataset {
+		fmt.Fprintln(os.Stderr, "WARN: Dataset has unexpected whitespace, using trimmed version:", trimmedDataset)
 	}
 	return trimmedDataset
 }

--- a/libhoney_test.go
+++ b/libhoney_test.go
@@ -1170,7 +1170,7 @@ func TestConfigVariationsForClassicNonClassic(t *testing.T) {
 		{
 			apikey:          "d68f9ed1e96432ac1a3380",
 			dataset:         "",
-			expectedDataset: "unknown_service",
+			expectedDataset: "unknown_dataset",
 		},
 		{
 			apikey:          "d68f9ed1e96432ac1a3380",

--- a/libhoney_test.go
+++ b/libhoney_test.go
@@ -1145,3 +1145,45 @@ func TestEventStringReturnsMaskedApiKey(t *testing.T) {
 		testEquals(t, test.ev.String(), test.expStr)
 	}
 }
+
+func TestConfigVariationsForClassicNonClassic(t *testing.T) {
+	tests := []struct {
+		apikey          string
+		dataset         string
+		expectedDataset string
+	}{
+		{
+			apikey:          "",
+			dataset:         "",
+			expectedDataset: "libhoney-go dataset",
+		},
+		{
+			apikey:          "c1a551c000d68f9ed1e96432ac1a3380",
+			dataset:         "",
+			expectedDataset: "libhoney-go dataset",
+		},
+		{
+			apikey:          "c1a551c000d68f9ed1e96432ac1a3380",
+			dataset:         " my-service ",
+			expectedDataset: " my-service ",
+		},
+		{
+			apikey:          "d68f9ed1e96432ac1a3380",
+			dataset:         "",
+			expectedDataset: "unknown_service",
+		},
+		{
+			apikey:          "d68f9ed1e96432ac1a3380",
+			dataset:         " my-service ",
+			expectedDataset: "my-service",
+		},
+	}
+
+	for _, tc := range tests {
+		config := Config{
+			APIKey:  tc.apikey,
+			Dataset: tc.dataset,
+		}
+		testEquals(t, config.getDataset(), tc.expectedDataset)
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Updates the config class to default to "unknown_dataset" or trim the dataset value if a non-classsic API (write) key is used. Default behaviour for classic API keys is unchanged.

- Closes #169 

## Short description of the changes
- Adds getDataset func that determines dataset, including getting defaults, based on the set API key
- Adds tests to verify behaviour

