### PR TITLE
maint: add go 1.18 to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,10 +20,10 @@ filters_publish: &filters_publish
 matrix_goversions: &matrix_goversions
   matrix:
     parameters:
-      goversion: ["14", "15", "16", "17"]
+      goversion: ["14", "15", "16", "17", "18"]
 
 # Default version of Go to use for Go steps
-default_goversion: &default_goversion "17"
+default_goversion: &default_goversion "18"
 
 executors:
   go:
@@ -61,13 +61,6 @@ jobs:
     steps:
       - buildevents/with_job_span:
           steps:
-            - when:
-                condition:
-                  equal: ["12", "<< parameters.goversion >>" ]
-                steps:
-                  - run:
-                      name: Update certs in old CI image
-                      command: sudo apt-get update && sudo apt-get install -y ca-certificates
             - checkout
             - run: go get -v -t -d ./...
             - run: go test -race -v ./...


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- go 1.18 was released earlier this month

## Short description of the changes

- add 1.18 to test matrix
- change default version to 1.18
- remove fix for older version (1.12) - no longer supported

