### PR TITLE
Build example app during CI test phase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,9 @@ jobs:
             - buildevents/add_context:
                 field_name: go_version
                 field_value: << parameters.goversion >>
-            - run: go build examples/read_json_log.go
+            - run:
+                name: Build example
+                command: go build examples/read_json_log.go
 
   publish_github:
     executor: github

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,7 @@ jobs:
             - buildevents/add_context:
                 field_name: go_version
                 field_value: << parameters.goversion >>
+            - run: go build examples/read_json_log.go
 
   publish_github:
     executor: github


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
We have a local example that demonstrates some expected usage patterns but is not tied directly to what it's the main projects. This change updates the CI build phase to also build the example to ensure we do not accidentally break APIs.

- Closes #176 

## Short description of the changes
- Build example app during CI test phase

<img width="1182" alt="image" src="https://user-images.githubusercontent.com/3481731/168244758-71686b27-b30a-4e0a-b03a-2b9bfc842ae3.png">
