### PR TITLE
Add support to retrieve team and environment

### DIFF
--- a/libhoney.go
+++ b/libhoney.go
@@ -370,7 +370,7 @@ func getAuth(config Config) (authInfo, error) {
 	}
 	body, _ := ioutil.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
-		return auth, fmt.Errorf(`Abnormal non-200 response verify Honeycomb write/API key: %d
+		return auth, fmt.Errorf(`Abnormal non-200 response verifying Honeycomb write/API key: %d
 Response body: %s`, resp.StatusCode, string(body))
 	}
 	if err := json.Unmarshal(body, &auth); err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Adds support for retrieving a team name and associated environment given an API key. This is similar to the existing VerifyWriteKey and VerifyAPIKey functions, but also returns the environment. The library uses the `1/auth` endpoint to retrieve this information.

## Short description of the changes
- Create shared func to retrieve team to use `1/auth` endpoint and also retrieve environment
- Update VerifyWriteKey and VerifyAPIKey to use new shared func
- Add `GetTeamAndEnvironment` func that uses the new shared logic
- Add unit tests to verify behaviour of all three functions

