### PR TITLE
release: prepare v1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,37 +1,29 @@
 # libhoney Changelog
 
-## 2.2.0 2022-07-13
+## 1.16.0 2022-07-13
 
-### Enhancements
+There were several v2 releases that were unusable because they were incomplete according to Go's semantic versioning strategy.
+Changes that appeared in those unusable v2 releases are consolidated into this minor release.
 
-- Add support to retrieve team and environment (#183) | [@MikeGoldsmith](https://github.com/MikeGoldsmith)
+### ⚠️ Breaking Changes ⚠️
 
-### Maintenance
-
-- maint: add go 1.18 to CI (#172) | [@vreynolds](https://github.com/vreynolds)
-- Update examples (#184) | [@vreynolds](https://github.com/vreynolds)
-- Build example app during CI test phase (#179) | [@MikeGoldsmith](https://github.com/MikeGoldsmith)
-- Bump github.com/stretchr/testify from 1.7.0 to 1.8.0 (#174, #181) | [dependabot](https://github.com/dependabot)
-- Bump github.com/klauspost/compress from 1.13.6 to 1.15.7 (#175, #177, #180, #182) | [dependabot](https://github.com/dependabot)
-- Bump github.com/DataDog/zstd from 1.5.0 to 1.5.2 (#178) | [dependabot](https://github.com/dependabot)
-
-## 2.1.0 2022-03-28
+Minimum Go version required is 1.14
 
 ### Enhancements
 
 - Update default dataset name for non-classic API keys (#170) | [@MikeGoldsmith](https://github.com/MikeGoldsmith)
-
-## 2.0.0 2022-02-10
-
-### !!! Breaking Changes !!!
-
-Minimum Go version required is 1.14
+- Add support to retrieve team and environment (#183) | [@MikeGoldsmith](https://github.com/MikeGoldsmith)
 
 ### Maintenance
 
-- Bump github.com/stretchr/testify from 1.6.1 to 1.7.0 (#111) | [dependabot](https://github.com/dependabot)
-- [go] drop support for go before 1.14 (#164) | [lizthegrey](https://github.com/lizthegrey)
+- maint: drop support for go before 1.14 (#164) | [lizthegrey](https://github.com/lizthegrey)
+- maint: add go 1.18 to CI (#172) | [@vreynolds](https://github.com/vreynolds)
 - Fix race condition in test and other test bugs (#162) | [@kentquirk](https://github.com/kentquirk)
+- Update examples (#184) | [@vreynolds](https://github.com/vreynolds)
+- Build example app during CI test phase (#179) | [@MikeGoldsmith](https://github.com/MikeGoldsmith)
+- Bump github.com/stretchr/testify from 1.6.1 to 1.8.0 (#111, #174, #181) | [dependabot](https://github.com/dependabot)
+- Bump github.com/klauspost/compress from 1.13.6 to 1.15.7 (#175, #177, #180, #182) | [dependabot](https://github.com/dependabot)
+- Bump github.com/DataDog/zstd from 1.5.0 to 1.5.2 (#178) | [dependabot](https://github.com/dependabot)
 
 ## 1.15.8 2022-01-05
 

--- a/libhoney.go
+++ b/libhoney.go
@@ -35,7 +35,7 @@ const (
 	defaultAPIHost        = "https://api.honeycomb.io/"
 	defaultClassicDataset = "libhoney-go dataset"
 	defaultDataset        = "unknown_dataset"
-	version               = "2.2.0"
+	version               = "1.16.0"
 
 	// DefaultMaxBatchSize how many events to collect in a batch
 	DefaultMaxBatchSize = 50


### PR DESCRIPTION
## Which problem is this PR solving?

There were several v2 releases that were unusable because they were incomplete according to Go's semantic versioning
strategy. Changes that appeared in those unusable v2 releases are consolidated into this minor release.

![My bad!](https://user-images.githubusercontent.com/517302/178823465-87a540d9-62d2-4b17-ba3d-fac365f039cd.gif)

