### PR TITLE
docs: add wiki manual tracing example

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,8 +68,11 @@ jobs:
                 field_name: go_version
                 field_value: << parameters.goversion >>
             - run:
-                name: Build example
+                name: Build JSON reader example
                 command: go build examples/json_reader/read_json_log.go
+            - run:
+                name: Build Wiki example
+                command: go build examples/wiki-manual-tracing/wiki.go
 
   publish_github:
     executor: github

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Example artifacts
+examples/wiki-manual-tracing/*.txt
+
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a

--- a/examples/json_reader/read_json_log.go
+++ b/examples/json_reader/read_json_log.go
@@ -33,9 +33,9 @@ func main() {
 	// basic initialization
 	libhConf := libhoney.Config{
 		// TODO change to use APIKey
-		WriteKey: honeyFakeAPIKey,
-		Dataset:  honeyDataset,
-		Logger:   &libhoney.DefaultLogger{},
+		APIKey:  honeyFakeAPIKey,
+		Dataset: honeyDataset,
+		Logger:  &libhoney.DefaultLogger{},
 	}
 	libhoney.Init(libhConf)
 

--- a/examples/wiki-manual-tracing/README.md
+++ b/examples/wiki-manual-tracing/README.md
@@ -1,0 +1,48 @@
+# golang-wiki-tracing
+
+This example illustrates a simple wiki application instrumented with the **bare minimum necessary** to utilize Honeycomb's tracing functionality, using the finished code from the ["Writing Web Applications" Golang tutorial](https://go.dev/doc/articles/wiki/).
+
+## What We'll Do in This Example
+
+We'll instrument a simple application for tracing by following a few general steps:
+
+1. Set a top-level `trace.trace_id` at the origin of the request and set it on the request context. Generate a root span indicated by omitting a `trace.parent_id` field.
+2. To represent a unit of work within a trace as a span, add code to generate a span ID and capture the start time. At the **call site** of the unit of work, pass down a new request context with the newly-generated span ID as the `trace.parent_id`. Upon work completion, send the span with a calculated `duration_ms`.
+3. Rinse and repeat.
+
+**Note**: Sound complicated? [OpenTelemetry for Go](https://docs.honeycomb.io/getting-data-in/opentelemetry/go/) handles all of this propagation magic for you :)
+
+## Usage
+
+You can [find your API key](https://docs.honeycomb.io/getting-data-in/api-keys/#find-api-keys) in your Environment Settings.
+If you do not have an API key yet, sign up for a [free Honeycomb account](https://ui.honeycomb.io/signup).
+
+Once you have your API key, run:
+
+```bash
+$ HONEYCOMB_API_KEY=foobarbaz go run wiki.go
+```
+
+And load [`http://localhost:8080/view/MyFirstWikiPage`](http://localhost:8080/view/MyFirstWikiPage) to create (then view) your first wiki page.
+
+Methods within the simple wiki application have been instrumented with tracing-like calls, with context and tracing identifiers propagated via a `context.Context`.
+
+## Tips for Instrumenting Your Own Service
+
+- For a given span (e.g. `"loadPage"`), remember that the span definition lives in its parent, and the instrumentation is around the **call site** of `loadPage`:
+    ```go
+    loadPageID := fmt.Sprintf("%x", rand.Int63())
+    start := time.Now()
+    // Make sure to pass newContextWithParentID() -- with loadPageID as the
+    // parent ID -- to loadPage in order to propagate span inheritance correctly
+    loadPage(newContextWithParentID(r.Context(), loadPageID), title)
+    sendSpan("loadPage", loadPageID, start, r.Context())
+    ```
+- If emitting Honeycomb events or structured logs, make sure that the **start** time gets used as the canonical timestamp, not the time at event emission.
+- Remember, the root span should **not** have a `trace.parent_id`.
+- Don't forget to add some metadata of your own! It's helpful to identify metadata in the surrounding code that might be interesting when debugging your application.
+- Check out our [OpenTelemetry for Go](https://docs.honeycomb.io/getting-data-in/opentelemetry/go/) to get this context propagation for free!
+
+## A Note on Code Style
+
+The purpose of this example is to illustrate the **bare minimum necessary** to propagate and set identifiers to enable tracing on an application for consumption by Honeycomb, illustrating the steps described in the top section of this README. We prioritized legibility over style and intentionally resisted refactoring that would sacrifice clarity. :)

--- a/examples/wiki-manual-tracing/edit.html
+++ b/examples/wiki-manual-tracing/edit.html
@@ -1,0 +1,6 @@
+<h1>Editing {{.Title}}</h1>
+
+<form action="/save/{{.Title}}" method="POST">
+<div><textarea name="body" rows="20" cols="80">{{printf "%s" .Body}}</textarea></div>
+<div><input type="submit" value="Save"></div>
+</form>

--- a/examples/wiki-manual-tracing/view.html
+++ b/examples/wiki-manual-tracing/view.html
@@ -1,0 +1,5 @@
+<h1>{{.Title}}</h1>
+
+<p>[<a href="/edit/{{.Title}}">edit</a>]</p>
+
+<div>{{printf "%s" .Body}}</div>

--- a/examples/wiki-manual-tracing/wiki.go
+++ b/examples/wiki-manual-tracing/wiki.go
@@ -1,0 +1,219 @@
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"html/template"
+	"io/ioutil"
+	"log"
+	"math/rand"
+	"net/http"
+	"os"
+	"regexp"
+	"time"
+
+	"github.com/honeycombio/libhoney-go"
+)
+
+type key int
+
+const (
+	requestIDKey key = 0
+	parentIDKey  key = 1
+)
+
+// Define some wrappers to propagate "trace" or "request" identifiers down the
+// call stack, to unify the various spans within a trace.
+func newContextWithRequestID(ctx context.Context, req *http.Request) context.Context {
+	reqID := req.Header.Get("X-Request-ID")
+	if reqID == "" {
+		reqID = newID()
+	}
+	return context.WithValue(ctx, requestIDKey, reqID)
+}
+
+func requestIDFromContext(ctx context.Context) string {
+	return ctx.Value(requestIDKey).(string)
+}
+
+// Define some wrappers to propagate "parent" identifiers down the call stack,
+// for defining relationships between spans within a trace.
+func newContextWithParentID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, parentIDKey, id)
+}
+
+func parentIDFromContext(ctx context.Context) string {
+	if id, ok := ctx.Value(parentIDKey).(string); ok {
+		return id
+	}
+	return ""
+}
+
+// Generate a new unique identifier for our spans and traces. This can be any
+// unique string -- Zipkin uses hex-encoded base64 ints, as we do here; other
+// folks may prefer to use their UUID library of choice.
+func newID() string {
+	return fmt.Sprintf("%x", rand.Int63())
+}
+
+// Page represents the data (and some basic operations) on a wiki page.
+//
+// While the tracing instrumentation in this example is constrained to the
+// handlers, we could just as easily propagate context down directly into this
+// class if needed.
+type Page struct {
+	Title string
+	Body  []byte
+}
+
+func (p *Page) save(ctx context.Context) error {
+	filename := p.Title + ".txt"
+	return ioutil.WriteFile(filename, p.Body, 0600)
+}
+
+func loadPage(ctx context.Context, title string) (*Page, error) {
+	filename := title + ".txt"
+	id := newID()
+	start := time.Now()
+	body, err := ioutil.ReadFile(filename)
+	sendSpan("ioutil.ReadFile", id, start, ctx, map[string]interface{}{"title": title, "bodylen": len(body), "error": err})
+	if err != nil {
+		return nil, err
+	}
+	return &Page{Title: title, Body: body}, nil
+}
+
+// Our "View" handler. Tries to load a page from disk and render it. Falls back
+// to the Edit handler if the page does not yet exist.
+func viewHandler(w http.ResponseWriter, r *http.Request, title string) {
+	loadPageID := newID()
+	loadPageStart := time.Now()
+	p, err := loadPage(newContextWithParentID(r.Context(), loadPageID), title)
+	sendSpan("loadPage", loadPageID, loadPageStart, r.Context(), map[string]interface{}{"title": title, "error": err})
+	if err != nil {
+		http.Redirect(w, r, "/edit/"+title, http.StatusFound)
+		return
+	}
+	renderID := newID()
+	renderStart := time.Now()
+	renderTemplate(newContextWithParentID(r.Context(), renderID), w, "view", p)
+	sendSpan("renderTemplate", renderID, renderStart, r.Context(), map[string]interface{}{"template": "view"})
+}
+
+// Our "Edit" handler. Tries to load a page from disk to seed the edit screen,
+// then renders a form to allow the user to define the content of the requested
+// wiki page.
+func editHandler(w http.ResponseWriter, r *http.Request, title string) {
+	loadPageID := newID()
+	loadPageStart := time.Now()
+	p, err := loadPage(newContextWithParentID(r.Context(), loadPageID), title)
+	sendSpan("loadPage", loadPageID, loadPageStart, r.Context(), map[string]interface{}{"title": title, "error": err})
+	if err != nil {
+		p = &Page{Title: title}
+	}
+	renderID := newID()
+	renderStart := time.Now()
+	renderTemplate(newContextWithParentID(r.Context(), renderID), w, "edit", p)
+	sendSpan("renderTemplate", renderID, renderStart, r.Context(), map[string]interface{}{"template": "edit"})
+}
+
+// Our "Save" handler simply persists a page to disk.
+func saveHandler(w http.ResponseWriter, r *http.Request, title string) {
+	body := r.FormValue("body")
+	p := &Page{Title: title, Body: []byte(body)}
+	id := newID()
+	start := time.Now()
+	err := p.save(newContextWithParentID(r.Context(), id))
+	sendSpan("ioutil.WriteFile", id, start, r.Context(), map[string]interface{}{"title": title, "bodylen": len(body), "error": err})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	http.Redirect(w, r, "/view/"+title, http.StatusFound)
+}
+
+var templates = template.Must(template.ParseFiles("edit.html", "view.html"))
+
+func renderTemplate(ctx context.Context, w http.ResponseWriter, tmpl string, p *Page) {
+	err := templates.ExecuteTemplate(w, tmpl+".html", p)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+var validPath = regexp.MustCompile("^/(edit|save|view)/([a-zA-Z0-9]+)$")
+
+// This middleware treats each HTTP request as a distinct "trace." Each trace
+// begins with a top-level ("root") span indicating that the HTTP request has
+// begun.
+func makeHandler(fn func(http.ResponseWriter, *http.Request, string)) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		m := validPath.FindStringSubmatch(r.URL.Path)
+		if m == nil {
+			http.NotFound(w, r)
+			return
+		}
+		start := time.Now()
+		id := newID()
+		ctx := newContextWithRequestID(r.Context(), r)
+		fn(w, r.WithContext(newContextWithParentID(ctx, id)), m[2])
+		sendSpan(m[1], id, start, ctx, nil)
+	}
+}
+
+// This wrapper takes a span name and some optional metadata, then emits a
+// "span" to Honeycomb as part of the trace begun in the HTTP middleware.
+func sendSpan(name, id string, start time.Time, ctx context.Context, metadata map[string]interface{}) {
+	if metadata == nil {
+		metadata = map[string]interface{}{}
+	}
+	// Field keys to trigger Honeycomb's tracing functionality on this dataset
+	// defined at:
+	// https://docs.honeycomb.io/getting-data-in/tracing/send-trace-data/
+	metadata["name"] = name
+	metadata["trace.span_id"] = id
+	metadata["trace.trace_id"] = requestIDFromContext(ctx)
+	metadata["service.name"] = "wiki"
+	metadata["duration_ms"] = float64(time.Since(start)) / float64(time.Millisecond)
+	if parentID := parentIDFromContext(ctx); parentID != "" {
+		metadata["trace.parent_id"] = parentID
+	}
+
+	ev := libhoney.NewEvent()
+	// NOTE: Don't forget to set the timestamp to `start` -- because spans are
+	// emitted at the *end* of their execution, we want to be doubly sure that
+	// our manually-emitted events are timestamped with the time that the work
+	// (the span's actual execution) really begun.
+	ev.Timestamp = start
+	ev.Add(metadata)
+	ev.Send()
+}
+
+// Let's go!
+func main() {
+	libhoney.Init(libhoney.Config{
+		APIKey:  os.Getenv("HONEYCOMB_API_KEY"),
+		Dataset: "golang-wiki-tracing-example",
+	})
+	defer libhoney.Close()
+
+	http.HandleFunc("/view/", makeHandler(viewHandler))
+	http.HandleFunc("/edit/", makeHandler(editHandler))
+	http.HandleFunc("/save/", makeHandler(saveHandler))
+	// Redirect to a default wiki page.
+	http.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/" {
+			http.NotFound(w, req)
+			return
+		}
+		h := http.RedirectHandler("/view/Index", http.StatusTemporaryRedirect)
+		h.ServeHTTP(w, req)
+	})
+
+	log.Print("Serving app on localhost:8080 ....")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- while not the most common use case, we do have a path in the docs for manual tracing that references this example

## Short description of the changes

- ported from https://github.com/honeycombio/examples/tree/d94f9d56398f6546404c13b4df0674ed3b412e4e/golang-wiki-tracing
- replaced trace fields with OTel format
- suggested OTel Go for automatic tracing
- built in CI

update deprecated config option in other example
