### PR TITLE
[feat] adds a configurable event batch send timeout

### DIFF
--- a/transmission/transmission.go
+++ b/transmission/transmission.go
@@ -30,27 +30,42 @@ import (
 )
 
 const (
-	apiMaxBatchSize    int = 5000000 // 5MB
-	apiEventSizeMax    int = 100000  // 100KB
+	// Size limit for a serialized request body sent for a batch.
+	apiMaxBatchSize int = 5000000 // 5MB
+	// Size limit for a single serialized event within a batch.
+	apiEventSizeMax    int = 100000 // 100KB
 	maxOverflowBatches int = 10
-	defaultSendTimeout     = time.Second * 60
+	// Default start-to-finish timeout for batch send HTTP requests.
+	defaultSendTimeout = time.Second * 60
 )
 
 // Version is the build version, set by libhoney
 var Version string
 
 type Honeycomb struct {
-	// how many events to collect into a batch before sending
+	// How many events to collect into a batch before sending. A
+	// batch could be sent before achieving this item limit if the
+	// BatchTimeout has elapsed since the last batch send. If set
+	// to zero, batches will only be sent upon reaching the
+	// BatchTimeout. It is an error for both this and
+	// the BatchTimeout to be zero.
+	// Default: 50 (from Config.MaxBatchSize)
 	MaxBatchSize uint
 
 	// How often to send batches. Events queue up into a batch until
-	// this time has elapsed, then the batch is sent to Honeycomb API.
+	// this time has elapsed or the batch item limit is reached
+	// (MaxBatchSize), then the batch is sent to Honeycomb API.
+	// If set to zero, batches will only be sent upon reaching the
+	// MaxBatchSize item limit. It is an error for both this and
+	// the MaxBatchSize to be zero.
+	// Default: 100 milliseconds (from Config.SendFrequency)
 	BatchTimeout time.Duration
 
-	// The end-to-end timeout for batch send HTTP requests to Honeycomb API.
+	// The start-to-finish timeout for HTTP requests sending event
+	// batches to the Honeycomb API. Transmission will retry once
+	// when receiving a timeout, so total time spent attempting to
+	// send events could be twice this value.
 	// Default: 60 seconds.
-	// Note: transmission will retry once for a timeout, so total time
-	// spent attempting to send events could be twice this value.
 	BatchSendTimeout time.Duration
 
 	// how many batches can be inflight simultaneously

--- a/transmission/transmission_test.go
+++ b/transmission/transmission_test.go
@@ -392,6 +392,18 @@ func TestTxSendSingle(t *testing.T) {
 		rsp = testGetResponse(t, b.responses)
 		testOK(t, rsp.Err)
 		testEquals(t, rsp.StatusCode, 202)
+
+		// test no more than one retry when first attempt times out
+		reset(b, frt, 200, `[{"status":202}]`, nil)
+		b.httpClient.Transport = &TimingOutRoundTripper{
+			FakeRoundTripper: frt,
+			numTimeouts:      2,
+		}
+		b.Add(e)
+		b.Fire(&testNotifier{})
+		rsp = testGetResponse(t, b.responses)
+		testErr(t, rsp.Err)
+		testEquals(t, rsp.Err.Error(), "Post \"http://fakeHost:8080/1/batch/ds1\": timeout")
 	})
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?

- The lack of a configurable batch send timeout can leave compute running waiting for timeouts longer than is worth the cost of keeping the compute running. Some very ephemeral compute environments prefer to fail fast instead of spending money on uptime.
- Some [backstory in the Pollinators Slack](https://honeycombpollinators.slack.com/archives/C4T3A32CX/p1662710519156409?thread_ts=1662710405.668229&cid=C4T3A32CX) wherein AWS Lambdas spent some dollars during an extended ingest incident that caused long response times.

## Short description of the changes

- a little refactor to the test timeout roundtripper to teach it to count how many timeouts it ought to return
- added a test to confirm timeout responses result in only 1 retry
- made the send timeout for batches configurable, keeping the previous 60 second default
