### PR TITLE
Revert "pre-define map capacities"

### DIFF
--- a/libhoney.go
+++ b/libhoney.go
@@ -538,10 +538,9 @@ func Flush() {
 // Contrary to its name, SendNow does not block and send data
 // immediately, but only enqueues to be sent asynchronously.
 // It is equivalent to:
-//
-//	ev := libhoney.NewEvent()
-//	ev.Add(data)
-//	ev.Send()
+//   ev := libhoney.NewEvent()
+//   ev.Add(data)
+//   ev.Send()
 //
 // Deprecated: SendNow is deprecated and may be removed in a future major release.
 func SendNow(data interface{}) error {
@@ -845,8 +844,8 @@ func (e *Event) SendPresampled() (err error) {
 	e.sendLock.Lock()
 	defer e.sendLock.Unlock()
 
-	e.lock.RLock()
-	defer e.lock.RUnlock()
+	e.fieldHolder.lock.RLock()
+	defer e.fieldHolder.lock.RUnlock()
 	if len(e.data) == 0 {
 		return errors.New("No metrics added to event. Won't send empty event.")
 	}
@@ -923,10 +922,9 @@ func (b *Builder) AddDynamicField(name string, fn func() interface{}) error {
 // Contrary to its name, SendNow does not block and send data
 // immediately, but only enqueues to be sent asynchronously.
 // It is equivalent to:
-//
-//	ev := builder.NewEvent()
-//	ev.Add(data)
-//	ev.Send()
+//   ev := builder.NewEvent()
+//   ev.Add(data)
+//   ev.Send()
 //
 // Deprecated: SendNow is deprecated and may be removed in a future major release.
 func (b *Builder) SendNow(data interface{}) error {
@@ -949,23 +947,18 @@ func (b *Builder) NewEvent() *Event {
 		Timestamp:  time.Now(),
 		client:     b.client,
 	}
-	// Set up locks
+	e.data = make(map[string]interface{})
+
 	b.lock.RLock()
 	defer b.lock.RUnlock()
-	b.dynFieldsLock.RLock()
-	defer b.dynFieldsLock.RUnlock()
-	e.lock.Lock()
-	defer e.lock.Unlock()
-
-	e.data = make(map[string]interface{}, len(b.data)+len(b.dynFields))
 	for k, v := range b.data {
 		e.data[k] = v
 	}
-
-	// create dynamic metrics.
+	// create dynamic metrics
+	b.dynFieldsLock.RLock()
+	defer b.dynFieldsLock.RUnlock()
 	for _, dynField := range b.dynFields {
-		// Perform the data mutation while locked.
-		e.data[dynField.name] = dynField.fn()
+		e.AddField(dynField.name, dynField.fn())
 	}
 	return e
 }
@@ -980,14 +973,12 @@ func (b *Builder) Clone() *Builder {
 		APIHost:    b.APIHost,
 		client:     b.client,
 	}
-
+	newB.data = make(map[string]interface{})
 	b.lock.RLock()
 	defer b.lock.RUnlock()
-	newB.data = make(map[string]interface{}, len(b.data))
 	for k, v := range b.data {
 		newB.data[k] = v
 	}
-
 	// copy dynamic metric generators
 	b.dynFieldsLock.RLock()
 	defer b.dynFieldsLock.RUnlock()


### PR DESCRIPTION
Reverts honeycombio/libhoney-go#197

The solution here adds additional locks and lacks configurability, and we'd like to first try a different path. A combination of vacation, time zones, and a weekend caused our wires to get crossed.