### PR TITLE
Prepare v1.17.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # libhoney Changelog
 
+## 1.17.1 2022-10-19
+
+### Fixed
+
+- Pre-define field map capacities (#197) | [lizthegrey](https://github.com/lizthegrey)
+
+### Maintenance
+
+- Add release file (#199) | [@vreynolds](https://github.com/vreynolds)
+- Add new project workflow (#196) | [@vreynolds](https://github.com/vreynolds)
+
 ## 1.17.0 2022-09-23
 
 ### Enhancements

--- a/libhoney.go
+++ b/libhoney.go
@@ -35,7 +35,7 @@ const (
 	defaultAPIHost        = "https://api.honeycomb.io/"
 	defaultClassicDataset = "libhoney-go dataset"
 	defaultDataset        = "unknown_dataset"
-	version               = "1.17.0"
+	version               = "1.17.1"
 
 	// DefaultMaxBatchSize how many events to collect in a batch
 	DefaultMaxBatchSize = 50


### PR DESCRIPTION
## Which problem is this PR solving?
Prepares the v1.17.1 release.

## Short description of the changes
- Updates libhoney version to 1.17.1
- Adds changelog entry

