### PR TITLE
Convert stray fmt.Printf into logger.Printf

### DIFF
--- a/transmission/transmission.go
+++ b/transmission/transmission.go
@@ -541,7 +541,7 @@ func (b *batchAgg) fireBatch(events []*Event) {
 	for _, resp := range batchResponses {
 		resp.Duration = dur / time.Duration(numEncoded)
 		for eIdx < len(events) && events[eIdx] == nil {
-			fmt.Printf("incr, eIdx: %d, len(evs): %d\n", eIdx, len(events))
+			b.logger.Printf("incr, eIdx: %d, len(evs): %d", eIdx, len(events))
 			eIdx++
 		}
 		if eIdx == len(events) { // just in case

--- a/transmission/transmission_test.go
+++ b/transmission/transmission_test.go
@@ -817,6 +817,7 @@ func TestFireBatchWithBrokenFirstEvent(t *testing.T) {
 	withJSONAndMsgpack(t, &doMsgpack, func(t *testing.T) {
 		trt := &testRoundTripper{}
 		b := &batchAgg{
+			logger:                &nullLogger{},
 			httpClient:            &http.Client{Transport: trt},
 			testNower:             &fakeNower{},
 			testBlocker:           &sync.WaitGroup{},
@@ -864,6 +865,7 @@ func TestFireBatchWithBrokenMiddleEvent(t *testing.T) {
 	runEvents := func(ev ...*Event) {
 		trt := &testRoundTripper{}
 		b := &batchAgg{
+			logger:     &nullLogger{},
 			httpClient: &http.Client{Transport: trt},
 			testNower:  &fakeNower{},
 			// testBlocker:           &sync.WaitGroup{},


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- There's a stray `fmt.Printf` line in `transmission.go`

## Short description of the changes

- I've converted it into a logger line, but I'm not sure if this is intentionally left in or not

