### PR TITLE
feat: include Go version, GOOS, & GOARCH in user-agent

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,8 +62,9 @@ jobs:
       - buildevents/with_job_span:
           steps:
             - checkout
-            - run: go get -v -t -d ./...
-            - run: go test -race -v ./...
+            - run: make test
+            - store_test_results:
+                path: ./unit-tests.xml
             - buildevents/add_context:
                 field_name: go_version
                 field_value: << parameters.goversion >>

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Example artifacts
 examples/wiki-manual-tracing/*.txt
 
+# Test report
+unit-tests.xml
+
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: test
+#: run the tests!
+test:
+ifeq (, $(shell which gotestsum))
+	@echo " ***"
+	@echo "Running with standard go test because gotestsum was not found on PATH. Consider installing gotestsum for friendlier test output!"
+	@echo " ***"
+	go test -race -v ./...
+else
+	gotestsum --junitfile unit-tests.xml --format testname -- -race ./...
+endif

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Creating a new release
 
-1. Update the version string in `libhoney.go`.
+1. Update the Version string in `version/version.go`.
 2. Add new release notes to the Changelog.
 3. Open a PR with above changes.
 4. Once the above PR is merged, tag `main` with the new version, e.g. `v0.1.1`. Push the tags. This will kick off a CI workflow, which will publish a draft GitHub release.

--- a/libhoney.go
+++ b/libhoney.go
@@ -27,7 +27,6 @@ import (
 
 func init() {
 	rand.Seed(time.Now().UnixNano())
-	transmission.Version = version
 }
 
 const (
@@ -35,7 +34,6 @@ const (
 	defaultAPIHost        = "https://api.honeycomb.io/"
 	defaultClassicDataset = "libhoney-go dataset"
 	defaultDataset        = "unknown_dataset"
-	version               = "1.17.1"
 
 	// DefaultMaxBatchSize how many events to collect in a batch
 	DefaultMaxBatchSize = 50

--- a/transmission/transmission.go
+++ b/transmission/transmission.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -408,7 +409,7 @@ func (b *batchAgg) fireBatch(events []*Event) {
 	url.Path = path.Join(url.Path, "/1/batch", dataset)
 
 	// sigh. dislike
-	userAgent := fmt.Sprintf("libhoney-go/%s", Version)
+	userAgent := fmt.Sprintf("libhoney-go/%s (%s/%s)", Version, runtime.GOOS, runtime.GOARCH)
 	if b.userAgentAddition != "" {
 		userAgent = fmt.Sprintf("%s %s", userAgent, strings.TrimSpace(b.userAgentAddition))
 	}

--- a/transmission/transmission_test.go
+++ b/transmission/transmission_test.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -229,7 +230,7 @@ func TestTxSendSingle(t *testing.T) {
 		b.Fire(&testNotifier{})
 		expectedURL := fmt.Sprintf("%s/1/batch/%s", e.APIHost, e.Dataset)
 		testEquals(t, frt.req.URL.String(), expectedURL)
-		versionedUserAgent := fmt.Sprintf("libhoney-go/%s", Version)
+		versionedUserAgent := fmt.Sprintf("libhoney-go/%s (%s/%s)", Version, runtime.GOOS, runtime.GOARCH)
 		testEquals(t, frt.req.Header.Get("User-Agent"), versionedUserAgent)
 		testEquals(t, frt.req.Header.Get("X-Honeycomb-Team"), e.APIKey)
 		buf := &bytes.Buffer{}

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,5 @@
+package version
+
+const (
+	Version string = "1.17.1"
+)


### PR DESCRIPTION
## Which problem is this PR solving?

It helps Honeycomb support customers to know what operating systems and CPU architectures instrumentation is running upon. OpenTelemetry has added this to the Collector and the spec for Exporters and we have [prior art for this in libhoney-rb](https://github.com/honeycombio/libhoney-rb/pull/105).

## Short description of the changes

- Updated the user-agent to include Go version, GOOS, and GOARCH

- Makefile addition with a test target to bring the CI test execution mechanism up-to-date with what we're doing in other Go codebases to make it easy to run the tests, make it each to read the test output, and give CI the data it needs to helps us see test failures more clearly.

- Moved our libhoney version declaration out of the parent libhoney
package and into version so that other packages (transmission) can
reference it. That allows the usual user-agent to be pre-computed.

- User-agent assertions updated to use testify because the failure output
for diffs is so much friendlier.

