### PR TITLE
ci: add go 1.20 to ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,10 +17,10 @@ filters_publish: &filters_publish
 matrix_goversions: &matrix_goversions
   matrix:
     parameters:
-      goversion: ["14", "15", "16", "17", "18", "19"]
+      goversion: ["14", "15", "16", "17", "18", "19", "20"]
 
 # Default version of Go to use for Go steps
-default_goversion: &default_goversion "18"
+default_goversion: &default_goversion "20"
 
 executors:
   go:


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Go 1.20 was released in February!

## Short description of the changes

Add 1.20 to test matrix and use as default version.

