### PR TITLE
maint: drop go 14, 15, 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ filters_publish: &filters_publish
 matrix_goversions: &matrix_goversions
   matrix:
     parameters:
-      goversion: ["14", "15", "16", "17", "18", "19", "20"]
+      goversion: ["17", "18", "19", "20"]
 
 # Default version of Go to use for Go steps
 default_goversion: &default_goversion "20"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For tracing support and automatic instrumentation of Gorilla, `httprouter`, `sql
 
 ## Dependencies
 
-Golang 1.14+
+Golang 1.17+
 
 ## Contributions
 


### PR DESCRIPTION
## Which problem is this PR solving?

- 16 has been eol since march 2022
- catalyst is [upgrading testify](https://github.com/honeycombio/libhoney-go/pull/224), which no longer works with those older versions

