### PR TITLE
perf: allow pre-sizing the data map

### DIFF
--- a/libhoney.go
+++ b/libhoney.go
@@ -939,6 +939,10 @@ func (b *Builder) SendNow(data interface{}) error {
 // NewEvent creates a new Event prepopulated with fields, dynamic
 // field values, and configuration inherited from the builder.
 func (b *Builder) NewEvent() *Event {
+	return b.NewEventSized(0)
+}
+
+func (b *Builder) NewEventSized(size int) *Event {
 	e := &Event{
 		WriteKey:   b.WriteKey,
 		Dataset:    b.Dataset,
@@ -955,7 +959,7 @@ func (b *Builder) NewEvent() *Event {
 	e.lock.Lock()
 	defer e.lock.Unlock()
 
-	e.data = make(map[string]interface{}, len(b.data)+len(b.dynFields))
+	e.data = make(map[string]interface{}, size+len(b.data)+len(b.dynFields))
 	for k, v := range b.data {
 		e.data[k] = v
 	}


### PR DESCRIPTION
## Which problem is this PR solving?
- See https://github.com/honeycombio/refinery/issues/749

## Short description of the changes
- Adds `NewEventSized()` for preallocating `e.data` for a known number of fields where performance is critical and the map should need to avoid being copied/resized on the fly.