### PR TITLE
feat: Add AddFieldIfUnset method to events

### DIFF
--- a/libhoney.go
+++ b/libhoney.go
@@ -623,6 +623,21 @@ func (f *fieldHolder) AddField(key string, val interface{}) {
 	f.data[key] = val
 }
 
+// AddFieldIfUnset adds an individual metric to the event or builder on which it is
+// called. It will only do so if the field has not already been set on the event.
+// This can be useful for providing "default" values of fields at a global level,
+// while still allowing individual events to provide an override.
+//
+// Note that if you add a value that cannot be serialized to JSON (eg a
+// function or channel), the event will fail to send.
+func (f *fieldHolder) AddFieldIfUnset(key string, val interface{}) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	if _, isset := f.data[key]; !isset {
+		f.data[key] = val
+	}
+}
+
 // Add adds a complex data type to the event or builder on which it's called.
 // For structs, it adds each exported field. For maps, it adds each key/value.
 // Add will error on all other types.

--- a/libhoney_test.go
+++ b/libhoney_test.go
@@ -148,6 +148,30 @@ func TestAddField(t *testing.T) {
 	testEquals(t, ev.data["boolVal"], true)
 }
 
+func TestAddFieldIfUnset(t *testing.T) {
+	resetPackageVars()
+	conf := Config{
+		WriteKey:   "aoeu",
+		Dataset:    "oeui",
+		SampleRate: 1,
+		APIHost:    "http://localhost:8081/",
+	}
+	Init(conf)
+	ev := NewEvent()
+	ev.AddFieldIfUnset("key", 1)
+	testEquals(t, ev.data["key"], 1)
+
+	ev.AddFieldIfUnset("key", 2)
+	testEquals(t, ev.data["key"], 1)
+
+	ev.AddField("key", 3)
+	// AddField will still overwrite
+	testEquals(t, ev.data["key"], 3)
+
+	ev.AddFieldIfUnset("key", 4)
+	testEquals(t, ev.data["key"], 3)
+}
+
 type Aich struct {
 	F1 string
 	F2 int


### PR DESCRIPTION
In beeline-go, trace-level fields take precedence over span-level fields. This is because we add the trace-level fields to the span at the very end of it's life, just before it's sent.

While we could move the point at which trace-level fields are added to spans, that feels... like too much backwards incompatibility, and instead I'd like to propose having trace-level fields added as "defaults" - so we won't override the fields that are added to the specific span.
