### PR TITLE
feat: support classic-flavored ingest keys

### DIFF
--- a/libhoney.go
+++ b/libhoney.go
@@ -74,8 +74,8 @@ var sd, _ = statsd.New(statsd.Mute(true), statsd.Prefix("libhoney"))
 // expected format is product-name/version, eg "myapp/1.0"
 var UserAgentAddition string
 
-var classicKeyRegex = regexp.MustCompile(`^[a-zA-Z0-9]{32}$`)
-var classicIngestKeyRegex = regexp.MustCompile(`^hc[a-z]ic_[a-z0-9]{58}$`)
+var classicKeyRegex = regexp.MustCompile(`^[a-f0-9]*$`)
+var classicIngestKeyRegex = regexp.MustCompile(`^hc[a-z]ic_[a-z0-9]*$`)
 
 // Config specifies settings for initializing the library.
 type Config struct {
@@ -169,7 +169,14 @@ func (c *Config) getDataset() string {
 }
 
 func (c *Config) IsClassic() bool {
-	return c.APIKey == "" || classicKeyRegex.MatchString(c.APIKey) || classicIngestKeyRegex.MatchString(c.APIKey)
+	if len(c.APIKey) == 0 {
+		return true
+	} else if len(c.APIKey) == 32 {
+		return classicKeyRegex.MatchString(c.APIKey)
+	} else if len(c.APIKey) == 64 {
+		return classicIngestKeyRegex.MatchString(c.APIKey)
+	}
+	return false
 }
 
 // Init is called on app initialization and passed a Config struct, which

--- a/libhoney.go
+++ b/libhoney.go
@@ -74,7 +74,7 @@ var sd, _ = statsd.New(statsd.Mute(true), statsd.Prefix("libhoney"))
 // expected format is product-name/version, eg "myapp/1.0"
 var UserAgentAddition string
 
-var classicKeyRegex = regexp.MustCompile(`^[a-z0-9]{32}$`)
+var classicKeyRegex = regexp.MustCompile(`^[a-zA-Z0-9]{32}$`)
 var classicIngestKeyRegex = regexp.MustCompile(`^hc[a-z]ic_[a-z0-9]{58}$`)
 
 // Config specifies settings for initializing the library.

--- a/libhoney.go
+++ b/libhoney.go
@@ -74,6 +74,7 @@ var sd, _ = statsd.New(statsd.Mute(true), statsd.Prefix("libhoney"))
 // expected format is product-name/version, eg "myapp/1.0"
 var UserAgentAddition string
 
+var classicKeyRegex = regexp.MustCompile(`^[a-z0-9]{32}$`)
 var classicIngestKeyRegex = regexp.MustCompile(`^hc[a-z]ic_[a-z0-9]{58}$`)
 
 // Config specifies settings for initializing the library.
@@ -168,7 +169,7 @@ func (c *Config) getDataset() string {
 }
 
 func (c *Config) IsClassic() bool {
-	return c.APIKey == "" || len(c.APIKey) == 32 || classicIngestKeyRegex.MatchString(c.APIKey)
+	return c.APIKey == "" || classicKeyRegex.MatchString(c.APIKey) || classicIngestKeyRegex.MatchString(c.APIKey)
 }
 
 // Init is called on app initialization and passed a Config struct, which

--- a/libhoney.go
+++ b/libhoney.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path"
 	"reflect"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -72,6 +73,8 @@ var sd, _ = statsd.New(statsd.Mute(true), statsd.Prefix("libhoney"))
 // contents will be appended to the User-Agent string, separated by a space. The
 // expected format is product-name/version, eg "myapp/1.0"
 var UserAgentAddition string
+
+var classicIngestKeyRegex = regexp.MustCompile(`^hc[a-z]ic_[a-z0-9]{58}$`)
 
 // Config specifies settings for initializing the library.
 type Config struct {
@@ -147,7 +150,7 @@ type Config struct {
 }
 
 func (c *Config) getDataset() string {
-	if c.isClassic() {
+	if c.IsClassic() {
 		if strings.TrimSpace(c.Dataset) == "" {
 			return defaultClassicDataset
 		}
@@ -164,8 +167,8 @@ func (c *Config) getDataset() string {
 	return trimmedDataset
 }
 
-func (c *Config) isClassic() bool {
-	return c.APIKey == "" || len(c.APIKey) == 32
+func (c *Config) IsClassic() bool {
+	return c.APIKey == "" || len(c.APIKey) == 32 || classicIngestKeyRegex.MatchString(c.APIKey)
 }
 
 // Init is called on app initialization and passed a Config struct, which

--- a/libhoney_test.go
+++ b/libhoney_test.go
@@ -1214,7 +1214,7 @@ func TestVerifyAPIKey(t *testing.T) {
 		APIKey              string
 		expectedEnvironment string
 	}{
-		{Name: "classic", APIKey: "lcYrFflRUR6rHbIifwqhfGRUR6rHbIic", expectedEnvironment: ""},
+		{Name: "classic", APIKey: "lcyrfflrur6rhbiifwqhfgrur6rhbiic", expectedEnvironment: ""},
 		{Name: "non-classic", APIKey: "lcYrFflRUR6rHbIifwqhfG", expectedEnvironment: "test_env"},
 	}
 

--- a/libhoney_test.go
+++ b/libhoney_test.go
@@ -1214,7 +1214,7 @@ func TestVerifyAPIKey(t *testing.T) {
 		APIKey              string
 		expectedEnvironment string
 	}{
-		{Name: "classic", APIKey: "lcyrfflrur6rhbiifwqhfgrur6rhbiic", expectedEnvironment: ""},
+		{Name: "classic", APIKey: "f2b9746602fd36049b222d3e8c6c48c9", expectedEnvironment: ""},
 		{Name: "non-classic", APIKey: "lcYrFflRUR6rHbIifwqhfG", expectedEnvironment: "test_env"},
 	}
 

--- a/libhoney_test.go
+++ b/libhoney_test.go
@@ -1155,12 +1155,12 @@ func TestConfigVariationsForClassicNonClassic(t *testing.T) {
 		{
 			apikey:          "",
 			dataset:         "",
-			expectedDataset: "libhoney-go dataset",
+			expectedDataset: defaultClassicDataset,
 		},
 		{
 			apikey:          "c1a551c000d68f9ed1e96432ac1a3380",
 			dataset:         "",
-			expectedDataset: "libhoney-go dataset",
+			expectedDataset: defaultClassicDataset,
 		},
 		{
 			apikey:          "c1a551c000d68f9ed1e96432ac1a3380",
@@ -1170,11 +1170,31 @@ func TestConfigVariationsForClassicNonClassic(t *testing.T) {
 		{
 			apikey:          "d68f9ed1e96432ac1a3380",
 			dataset:         "",
-			expectedDataset: "unknown_dataset",
+			expectedDataset: defaultDataset,
 		},
 		{
 			apikey:          "d68f9ed1e96432ac1a3380",
 			dataset:         " my-service ",
+			expectedDataset: "my-service",
+		},
+		{
+			apikey:          "hcxik_1234567890123456789012345678901234567890123456789012345678",
+			dataset:         "",
+			expectedDataset: defaultDataset,
+		},
+		{
+			apikey:          "hcxik_1234567890123456789012345678901234567890123456789012345678",
+			dataset:         "my-service",
+			expectedDataset: "my-service",
+		},
+		{
+			apikey:          "hcxic_1234567890123456789012345678901234567890123456789012345678",
+			dataset:         "",
+			expectedDataset: defaultClassicDataset,
+		},
+		{
+			apikey:          "hcxic_1234567890123456789012345678901234567890123456789012345678",
+			dataset:         "my-service",
 			expectedDataset: "my-service",
 		},
 	}
@@ -1209,7 +1229,7 @@ func TestVerifyAPIKey(t *testing.T) {
 					assert.Equal(t, "/1/auth", r.URL.Path)
 					assert.Equal(t, []string{tc.APIKey}, r.Header["X-Honeycomb-Team"])
 
-					if config.isClassic() {
+					if config.IsClassic() {
 						w.Write([]byte(`{"team":{"slug":"test_team"}}`))
 					} else {
 						w.Write([]byte(`{"team":{"slug":"test_team"},"environment":{"slug":"test_env"}}`))


### PR DESCRIPTION
## Which problem is this PR solving?

We've now released Ingest Keys, but in order for them to work with Classic environments properly we need to update the key detection logic.

## Short description of the changes

- updates the Classic API Key detection logic to understand the shape of a Classic Ingest Key
- makes the previously private `Config.isClassic` a public method (`Config.IsClassic`) to allow other projects to use this method and reduce the duplication of logic (i.e. beeline-go)