### PR TITLE
feat: introduce IsClassicKey helper function

### DIFF
--- a/libhoney.go
+++ b/libhoney.go
@@ -169,12 +169,16 @@ func (c *Config) getDataset() string {
 }
 
 func (c *Config) IsClassic() bool {
-	if len(c.APIKey) == 0 {
+	return IsClassicKey(c.APIKey)
+}
+
+func IsClassicKey(key string) bool {
+	if len(key) == 0 {
 		return true
-	} else if len(c.APIKey) == 32 {
-		return classicKeyRegex.MatchString(c.APIKey)
-	} else if len(c.APIKey) == 64 {
-		return classicIngestKeyRegex.MatchString(c.APIKey)
+	} else if len(key) == 32 {
+		return classicKeyRegex.MatchString(key)
+	} else if len(key) == 64 {
+		return classicIngestKeyRegex.MatchString(key)
 	}
 	return false
 }


### PR DESCRIPTION
## Which problem is this PR solving?

As a follow on to #237, we now realize it's more helpful to be able to determine if a key is a classic key just by the string and not just in the context of a `Config`.

## Short description of the changes

- Adds a new public function `IsClassicKey()` and updates `Config.IsClassic()` to use this without making a breaking change.

