### PR TITLE
feat: URL encode dataset

### DIFF
--- a/transmission/transmission.go
+++ b/transmission/transmission.go
@@ -422,7 +422,7 @@ func (b *batchAgg) fireBatch(events []*Event) {
 	}
 
 	// build the HTTP request
-	url.Path = path.Join(url.Path, "/1/batch", dataset)
+	url.Path = buildReqestPath(url.Path, dataset)
 
 	// One retry allowed for connection timeouts.
 	var resp *http.Response
@@ -741,4 +741,8 @@ func buildReqReader(jsonEncoded []byte, compress bool) (io.Reader, bool) {
 // nower to make testing easier
 type nower interface {
 	Now() time.Time
+}
+
+func buildReqestPath(existingPath, dataset string) string {
+	return path.Join(existingPath, "/1/batch", url.PathEscape(dataset))
 }

--- a/transmission/transmission_test.go
+++ b/transmission/transmission_test.go
@@ -1361,41 +1361,41 @@ func TestFireBatchWithUnauthorizedResponse(t *testing.T) {
 
 func TestBuildRequestPath(t *testing.T) {
 	testCases := []struct {
-		datasetName string
-		expectedUrl string
+		datasetName  string
+		expectedPath string
 	}{
 		{
-			datasetName: "foobar",
-			expectedUrl: "/1/batch/foobar",
+			datasetName:  "foobar",
+			expectedPath: "/1/batch/foobar",
 		},
 		{
-			datasetName: "foo.bar",
-			expectedUrl: "/1/batch/foo.bar",
+			datasetName:  "foo.bar",
+			expectedPath: "/1/batch/foo.bar",
 		},
 		{
-			datasetName: "foo-bar",
-			expectedUrl: "/1/batch/foo-bar",
+			datasetName:  "foo-bar",
+			expectedPath: "/1/batch/foo-bar",
 		},
 		{
-			datasetName: "foo/bar",
-			expectedUrl: "/1/batch/foo%2Fbar",
+			datasetName:  "foo/bar",
+			expectedPath: "/1/batch/foo%2Fbar",
 		},
 		{
-			datasetName: "foo(bar)",
-			expectedUrl: "/1/batch/foo%28bar%29",
+			datasetName:  "foo(bar)",
+			expectedPath: "/1/batch/foo%28bar%29",
 		},
 		{
-			datasetName: "foo[bar]",
-			expectedUrl: "/1/batch/foo%5Bbar%5D",
+			datasetName:  "foo[bar]",
+			expectedPath: "/1/batch/foo%5Bbar%5D",
 		},
 		{
-			datasetName: "foo{bar}",
-			expectedUrl: "/1/batch/foo%7Bbar%7D",
+			datasetName:  "foo{bar}",
+			expectedPath: "/1/batch/foo%7Bbar%7D",
 		},
 	}
 
 	for _, tc := range testCases {
 		path := buildReqestPath("", tc.datasetName)
-		assert.Equal(t, tc.expectedUrl, path)
+		assert.Equal(t, tc.expectedPath, path)
 	}
 }

--- a/transmission/transmission_test.go
+++ b/transmission/transmission_test.go
@@ -1358,3 +1358,44 @@ func TestFireBatchWithUnauthorizedResponse(t *testing.T) {
 		testEquals(t, l.logs[0], "APIKey 'written' was rejected. Please verify APIKey is correct.")
 	})
 }
+
+func TestBuildRequestPath(t *testing.T) {
+	testCases := []struct {
+		datasetName string
+		expectedUrl string
+	}{
+		{
+			datasetName: "foobar",
+			expectedUrl: "/1/batch/foobar",
+		},
+		{
+			datasetName: "foo.bar",
+			expectedUrl: "/1/batch/foo.bar",
+		},
+		{
+			datasetName: "foo-bar",
+			expectedUrl: "/1/batch/foo-bar",
+		},
+		{
+			datasetName: "foo/bar",
+			expectedUrl: "/1/batch/foo%2Fbar",
+		},
+		{
+			datasetName: "foo(bar)",
+			expectedUrl: "/1/batch/foo%28bar%29",
+		},
+		{
+			datasetName: "foo[bar]",
+			expectedUrl: "/1/batch/foo%5Bbar%5D",
+		},
+		{
+			datasetName: "foo{bar}",
+			expectedUrl: "/1/batch/foo%7Bbar%7D",
+		},
+	}
+
+	for _, tc := range testCases {
+		path := buildReqestPath("", tc.datasetName)
+		assert.Equal(t, tc.expectedUrl, path)
+	}
+}


### PR DESCRIPTION
## Which problem is this PR solving?

When sending data, the dataset name forms part of the URL path and should be URL encoded so restricted characters are preserved. This is particularly important if the dataset name included a forward slash `/` which results in an invalid URL path and the Honeycomb API rejecting the request.

## Short description of the changes
- URL encode the dataset before sending data
- Add tests to verify dataset is encoded correctly for use in the request path