### PR TITLE
chore: Update dependabot reviewer to pipeline-team

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
     labels:
       - "type: dependencies"
     reviewers:
-      - "honeycombio/telemetry-team"
+      - "honeycombio/pipeline-team"
     commit-message:
       prefix: "maint"
       include: "scope"


### PR DESCRIPTION
## Which problem is this PR solving?

The telemetry-team group has been removed and we should use pipeline-team instead.

## Short description of the changes
- Updates the reviewer for dependabot PRs to pipeline-team

