### PR TITLE
fix: Build the URL using url.JoinPath instead of path.Join

### DIFF
--- a/transmission/transmission.go
+++ b/transmission/transmission.go
@@ -423,7 +423,7 @@ func (b *batchAgg) fireBatch(events []*Event) {
 	}
 
 	// build the HTTP request URL
-	url := buildReqestPath(apiHost, dataset)
+	url := buildRequestURL(apiHost, dataset)
 
 	// One retry allowed for connection timeouts.
 	var resp *http.Response
@@ -744,6 +744,6 @@ type nower interface {
 	Now() time.Time
 }
 
-func buildReqestPath(apiHost, dataset string) string {
+func buildRequestURL(apiHost, dataset string) string {
 	return path.Join(apiHost, "/1/batch", url.PathEscape(dataset))
 }

--- a/transmission/transmission.go
+++ b/transmission/transmission.go
@@ -19,7 +19,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"path"
 	"runtime"
 	"strings"
 	"sync"
@@ -399,8 +398,7 @@ func (b *batchAgg) fireBatch(events []*Event) {
 		}
 	}
 
-	// make sure the api host is valid, if not, error out all the events
-	url, err := url.Parse(buildRequestURL(apiHost, dataset))
+	url, err := buildRequestURL(apiHost, dataset)
 	if err != nil {
 		end := time.Now().UTC()
 		if b.testNower != nil {
@@ -435,9 +433,9 @@ func (b *batchAgg) fireBatch(events []*Event) {
 			// Pass the underlying bytes.Reader to http.Request so that
 			// GetBody and ContentLength fields are populated on Request.
 			// See https://cs.opensource.google/go/go/+/refs/tags/go1.17.5:src/net/http/request.go;l=898
-			req, err = http.NewRequest("POST", url.String(), &reader.Reader)
+			req, err = http.NewRequest("POST", url, &reader.Reader)
 		} else {
-			req, err = http.NewRequest("POST", url.String(), reqBody)
+			req, err = http.NewRequest("POST", url, reqBody)
 		}
 		req.Header.Set("Content-Type", contentType)
 		if zipped {
@@ -741,6 +739,6 @@ type nower interface {
 	Now() time.Time
 }
 
-func buildRequestURL(apiHost, dataset string) string {
-	return path.Join(apiHost, "/1/batch", url.PathEscape(dataset))
+func buildRequestURL(apiHost, dataset string) (string, error) {
+	return url.JoinPath(apiHost, "/1/batch", url.PathEscape(dataset))
 }

--- a/transmission/transmission.go
+++ b/transmission/transmission.go
@@ -400,7 +400,7 @@ func (b *batchAgg) fireBatch(events []*Event) {
 	}
 
 	// make sure the api host is valid, if not, error out all the events
-	_, err := url.Parse(apiHost)
+	url, err := url.Parse(buildRequestURL(apiHost, dataset))
 	if err != nil {
 		end := time.Now().UTC()
 		if b.testNower != nil {
@@ -422,9 +422,6 @@ func (b *batchAgg) fireBatch(events []*Event) {
 		return
 	}
 
-	// build the HTTP request URL
-	url := buildRequestURL(apiHost, dataset)
-
 	// One retry allowed for connection timeouts.
 	var resp *http.Response
 	for try := 0; try < 2; try++ {
@@ -438,9 +435,9 @@ func (b *batchAgg) fireBatch(events []*Event) {
 			// Pass the underlying bytes.Reader to http.Request so that
 			// GetBody and ContentLength fields are populated on Request.
 			// See https://cs.opensource.google/go/go/+/refs/tags/go1.17.5:src/net/http/request.go;l=898
-			req, err = http.NewRequest("POST", url, &reader.Reader)
+			req, err = http.NewRequest("POST", url.String(), &reader.Reader)
 		} else {
-			req, err = http.NewRequest("POST", url, reqBody)
+			req, err = http.NewRequest("POST", url.String(), reqBody)
 		}
 		req.Header.Set("Content-Type", contentType)
 		if zipped {

--- a/transmission/transmission_test.go
+++ b/transmission/transmission_test.go
@@ -1395,7 +1395,7 @@ func TestBuildRequestPath(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		path := buildReqestPath("", tc.datasetName)
+		path := buildRequestURL("", tc.datasetName)
 		assert.Equal(t, tc.expectedPath, path)
 	}
 }

--- a/transmission/transmission_test.go
+++ b/transmission/transmission_test.go
@@ -1395,7 +1395,8 @@ func TestBuildRequestPath(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		path := buildRequestURL("", tc.datasetName)
-		assert.Equal(t, tc.expectedPath, path)
+		url, err := buildRequestURL("http://fakeHost:8080", tc.datasetName)
+		assert.NoError(t, err)
+		assert.Equal(t, "http://fakeHost:8080"+tc.expectedPath, url)
 	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?

There is a weird bug in setting a URL path directly, where it will escape some characters, but not all.

This [go playground](https://go.dev/play/p/QnMDXnU9lDq) example shows it. The unescaped value is used directly, the escaped value double escapes some of the characters.

This PR uses url.PathJoin instead, which is intended to handle URLs.

## Short description of the changes
- Update the URL builder to use url.JoinPath and return any errors
- Update Transmission to use updated builder func and handle error like before
- Update tests to handle errors