### PR TITLE
maint(build): add 1.23 to supported versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ filters_publish: &filters_publish
 matrix_goversions: &matrix_goversions
   matrix:
     parameters:
-      goversion: ["19", "20", "21", "22"]
+      goversion: ["19", "20", "21", "22", "23"]
 
 # Default version of Go to use for Go steps
 default_goversion: &default_goversion "20"


### PR DESCRIPTION
So long as we're internally relying upon libhoney we should run our tests against the go version we're using in hound. same rationale as #245