### PR TITLE
feat: improve error string for too large events

### DIFF
--- a/transmission/transmission.go
+++ b/transmission/transmission.go
@@ -587,13 +587,7 @@ func (b *batchAgg) encodeBatchJSON(events []*Event) ([]byte, int) {
 		// if the event is too large to ever send, add an error to the queue
 		if len(evByt) > apiEventSizeMax {
 			// if this event happens to have a `name` or `service.name` field, include them for easier debugging
-			var extraInfo string
-			if evName, ok := ev.Data["name"]; ok {
-				extraInfo = fmt.Sprintf(" Name: %v", evName)
-			}
-			if evServiceName, ok := ev.Data["service.name"]; ok {
-				extraInfo = fmt.Sprintf("%s Service Name: %v", extraInfo, evServiceName)
-			}
+			extraInfo := getExceedsMaxEventSizeExtraInfo(ev)
 			// log the error and enqueue a response
 			b.enqueueResponse(Response{
 				Err:      fmt.Errorf("event exceeds max event size of %d bytes, API will not accept this event.%s", apiEventSizeMax, extraInfo),
@@ -651,13 +645,7 @@ func (b *batchAgg) encodeBatchMsgp(events []*Event) ([]byte, int) {
 		// if the event is too large to ever send, add an error to the queue
 		if len(evByt) > apiEventSizeMax {
 			// if this event happens to have a `name` or `service.name` field, include them for easier debugging
-			var extraInfo string
-			if evName, ok := ev.Data["name"]; ok {
-				extraInfo = fmt.Sprintf(" Name: %v", evName)
-			}
-			if evServiceName, ok := ev.Data["service.name"]; ok {
-				extraInfo = fmt.Sprintf("%s Service Name: %v", extraInfo, evServiceName)
-			}
+			extraInfo := getExceedsMaxEventSizeExtraInfo(ev)
 			// log the error and enqueue a response
 			b.enqueueResponse(Response{
 				Err:      fmt.Errorf("event exceeds max event size of %d bytes, API will not accept this event.%s", apiEventSizeMax, extraInfo),
@@ -759,4 +747,15 @@ type nower interface {
 
 func buildRequestURL(apiHost, dataset string) (string, error) {
 	return url.JoinPath(apiHost, "/1/batch", url.PathEscape(dataset))
+}
+
+func getExceedsMaxEventSizeExtraInfo(ev *Event) string {
+	var extraInfo string
+	if evName, ok := ev.Data["name"]; ok {
+		extraInfo = fmt.Sprintf(" Name: %v", evName)
+	}
+	if evServiceName, ok := ev.Data["service.name"]; ok {
+		extraInfo = fmt.Sprintf("%s Service Name: %v", extraInfo, evServiceName)
+	}
+	return extraInfo
 }

--- a/transmission/transmission.go
+++ b/transmission/transmission.go
@@ -752,10 +752,10 @@ func buildRequestURL(apiHost, dataset string) (string, error) {
 func getExceedsMaxEventSizeExtraInfo(ev *Event) string {
 	var extraInfo string
 	if evName, ok := ev.Data["name"]; ok {
-		extraInfo = fmt.Sprintf(" Name: %v", evName)
+		extraInfo = fmt.Sprintf(" Name: \"%v\"", evName)
 	}
 	if evServiceName, ok := ev.Data["service.name"]; ok {
-		extraInfo = fmt.Sprintf("%s Service Name: %v", extraInfo, evServiceName)
+		extraInfo = fmt.Sprintf("%s Service Name: \"%v\"", extraInfo, evServiceName)
 	}
 	return extraInfo
 }

--- a/transmission/transmission.go
+++ b/transmission/transmission.go
@@ -586,8 +586,17 @@ func (b *batchAgg) encodeBatchJSON(events []*Event) ([]byte, int) {
 		}
 		// if the event is too large to ever send, add an error to the queue
 		if len(evByt) > apiEventSizeMax {
+			// if this event happens to have a `name` or `service.name` field, include them for easier debugging
+			var extraInfo string
+			if evName, ok := ev.Data["name"]; ok {
+				extraInfo = fmt.Sprintf(" Name: %v", evName)
+			}
+			if evServiceName, ok := ev.Data["service.name"]; ok {
+				extraInfo = fmt.Sprintf("%s Service Name: %v", extraInfo, evServiceName)
+			}
+			// log the error and enqueue a response
 			b.enqueueResponse(Response{
-				Err:      fmt.Errorf("event exceeds max event size of %d bytes, API will not accept this event", apiEventSizeMax),
+				Err:      fmt.Errorf("event exceeds max event size of %d bytes, API will not accept this event.%s", apiEventSizeMax, extraInfo),
 				Metadata: ev.Metadata,
 			})
 			events[i] = nil
@@ -641,8 +650,17 @@ func (b *batchAgg) encodeBatchMsgp(events []*Event) ([]byte, int) {
 		}
 		// if the event is too large to ever send, add an error to the queue
 		if len(evByt) > apiEventSizeMax {
+			// if this event happens to have a `name` or `service.name` field, include them for easier debugging
+			var extraInfo string
+			if evName, ok := ev.Data["name"]; ok {
+				extraInfo = fmt.Sprintf(" Name: %v", evName)
+			}
+			if evServiceName, ok := ev.Data["service.name"]; ok {
+				extraInfo = fmt.Sprintf("%s Service Name: %v", extraInfo, evServiceName)
+			}
+			// log the error and enqueue a response
 			b.enqueueResponse(Response{
-				Err:      fmt.Errorf("event exceeds max event size of %d bytes, API will not accept this event", apiEventSizeMax),
+				Err:      fmt.Errorf("event exceeds max event size of %d bytes, API will not accept this event.%s", apiEventSizeMax, extraInfo),
 				Metadata: ev.Metadata,
 			})
 			events[i] = nil

--- a/transmission/transmission_test.go
+++ b/transmission/transmission_test.go
@@ -786,15 +786,15 @@ func TestFireBatchWithTooLargeEvent(t *testing.T) {
 		}, {
 			desc:        "large event with a name",
 			fhData:      map[string]interface{}{"name": "namae", "reallyREALLYBigColumn": randomString(1024 * 1024)},
-			expectedErr: "event exceeds max event size of 100000 bytes, API will not accept this event. Name: namae",
+			expectedErr: "event exceeds max event size of 100000 bytes, API will not accept this event. Name: \"namae\"",
 		}, {
 			desc:        "large event with a service name",
 			fhData:      map[string]interface{}{"service.name": "servicio", "reallyREALLYBigColumn": randomString(1024 * 1024)},
-			expectedErr: "event exceeds max event size of 100000 bytes, API will not accept this event. Service Name: servicio",
+			expectedErr: "event exceeds max event size of 100000 bytes, API will not accept this event. Service Name: \"servicio\"",
 		}, {
 			desc:        "large event with a name and service name",
 			fhData:      map[string]interface{}{"name": "nom", "service.name": "servicio", "reallyREALLYBigColumn": randomString(1024 * 1024)},
-			expectedErr: "event exceeds max event size of 100000 bytes, API will not accept this event. Name: nom Service Name: servicio",
+			expectedErr: "event exceeds max event size of 100000 bytes, API will not accept this event. Name: \"nom\" Service Name: \"servicio\"",
 		}, {
 			desc:        "large event with other fields",
 			fhData:      map[string]interface{}{"f1": "racing", "team": "lotus", "reallyREALLYBigColumn": randomString(1024 * 1024)},


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

When libhoney encounters an event that is large enough that the Honeycomb API will reject it based on [published limits](https://docs.honeycomb.io/api/tag/Events#operation/createEvent), it preemptively refuses to send the event, knowing it will not be accepted. This error is logged so that the application author will realize that some telemetry is getting dropped. 

`event exceeds max event size of 100000 bytes, API will not accept this event`

However, it is exceedingly difficult to track down what telemetry it is that is getting dropped. There are no clues about where in the code this event might be generated, which field is too large, or anything else. 


## Short description of the changes

This PR examines the too-large event for the industry-standard fields `name` and `service.name` (standardized by Open Telemetry but also used by the beelines and other instrumentation). If those fields exist it will add their values to the error message. In the cases where the Honeycomb Beeline package is being used, this will indicate which span in a large trace is the offending span, dramatically shortening the process to find what fields might be added that are too large. 

There's a delicate balance here of wanting to add enough information to help the instrumentation author while not adding too much data from the (already too large) event. It wouldn't do if the notification that an event was too large was, itself, too large! Because of this danger this PR does not add additional information such a list of all fields to the error message. Name and service name will at least point the application author to the right span, then visual code analysis and other experiments can help narrow down what might be exceeding the event's size. 


