### PR TITLE
maint: Increase max event size, clean up some nits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,10 +17,10 @@ filters_publish: &filters_publish
 matrix_goversions: &matrix_goversions
   matrix:
     parameters:
-      goversion: ["19", "20", "21", "22", "23"]
+      goversion: ["21", "22", "23"]
 
 # Default version of Go to use for Go steps
-default_goversion: &default_goversion "20"
+default_goversion: &default_goversion "21"
 
 executors:
   go:

--- a/examples/wiki-manual-tracing/wiki.go
+++ b/examples/wiki-manual-tracing/wiki.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"html/template"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"net/http"
@@ -72,15 +71,15 @@ type Page struct {
 
 func (p *Page) save(ctx context.Context) error {
 	filename := p.Title + ".txt"
-	return ioutil.WriteFile(filename, p.Body, 0600)
+	return os.WriteFile(filename, p.Body, 0600)
 }
 
 func loadPage(ctx context.Context, title string) (*Page, error) {
 	filename := title + ".txt"
 	id := newID()
 	start := time.Now()
-	body, err := ioutil.ReadFile(filename)
-	sendSpan("ioutil.ReadFile", id, start, ctx, map[string]interface{}{"title": title, "bodylen": len(body), "error": err})
+	body, err := os.ReadFile(filename)
+	sendSpan("os.ReadFile", id, start, ctx, map[string]interface{}{"title": title, "bodylen": len(body), "error": err})
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +127,7 @@ func saveHandler(w http.ResponseWriter, r *http.Request, title string) {
 	id := newID()
 	start := time.Now()
 	err := p.save(newContextWithParentID(r.Context(), id))
-	sendSpan("ioutil.WriteFile", id, start, r.Context(), map[string]interface{}{"title": title, "bodylen": len(body), "error": err})
+	sendSpan("os.WriteFile", id, start, r.Context(), map[string]interface{}{"title": title, "bodylen": len(body), "error": err})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,13 @@
 module github.com/honeycombio/libhoney-go
 
-go 1.19
+go 1.21
+
+toolchain go1.23.4
 
 require (
 	github.com/DataDog/zstd v1.5.6
 	github.com/facebookgo/muster v0.0.0-20150708232844-fd3d7953fd52
-	github.com/klauspost/compress v1.17.9
+	github.com/klauspost/compress v1.17.11
 	github.com/stretchr/testify v1.10.0
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 	gopkg.in/alexcesaro/statsd.v2 v2.0.0

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/honeycombio/libhoney-go
 
 go 1.21
 
-toolchain go1.23.4
-
 require (
 	github.com/DataDog/zstd v1.5.6
 	github.com/facebookgo/muster v0.0.0-20150708232844-fd3d7953fd52

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 h1:JWuenKqqX8nojt
 github.com/facebookgo/stack v0.0.0-20160209184415-751773369052/go.mod h1:UbMTZqLaRiH3MsBH8va0n7s1pQYcu3uTb8G4tygF4Zg=
 github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4 h1:7HZCaLC5+BZpmbhCOZJ293Lz68O7PYrF2EzeiFMwCLk=
 github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4/go.mod h1:5tD+neXqOorC30/tWg0LCSkrqj/AR6gu8yY8/fpw1q0=
-github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
-github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
+github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
+github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=

--- a/libhoney.go
+++ b/libhoney.go
@@ -9,7 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -381,7 +381,7 @@ func getAuth(config Config) (authInfo, error) {
 	if resp.StatusCode == http.StatusUnauthorized {
 		return auth, errors.New("Write key provided is invalid")
 	}
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
 		return auth, fmt.Errorf(`Abnormal non-200 response verifying Honeycomb write/API key: %d
 Response body: %s`, resp.StatusCode, string(body))

--- a/libhoney_test.go
+++ b/libhoney_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -743,7 +743,7 @@ type testTransport struct {
 
 func (tr *testTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	tr.invoked = true
-	return &http.Response{Body: ioutil.NopCloser(bytes.NewReader(nil))}, nil
+	return &http.Response{Body: io.NopCloser(bytes.NewReader(nil))}, nil
 }
 
 func TestSendTestTransport(t *testing.T) {

--- a/transmission/response_test.go
+++ b/transmission/response_test.go
@@ -16,11 +16,11 @@ type responseInBatch struct {
 
 var (
 	srcBatchResponseSingle = []responseInBatch{
-		responseInBatch{ErrorStr: "something bad happened", Status: 500},
+		{ErrorStr: "something bad happened", Status: 500},
 	}
 	srcBatchResponseMultiple = []responseInBatch{
-		responseInBatch{ErrorStr: "something bad happened", Status: 500},
-		responseInBatch{Status: 202},
+		{ErrorStr: "something bad happened", Status: 500},
+		{Status: 202},
 	}
 )
 

--- a/transmission/transmission.go
+++ b/transmission/transmission.go
@@ -16,7 +16,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"runtime"
@@ -34,7 +33,7 @@ const (
 	// Size limit for a serialized request body sent for a batch.
 	apiMaxBatchSize int = 5000000 // 5MB
 	// Size limit for a single serialized event within a batch.
-	apiEventSizeMax    int = 100000 // 100KB
+	apiEventSizeMax    int = 1_000_000 // 1MB, which is the limit for a single event in Shepherd
 	maxOverflowBatches int = 10
 	// Default start-to-finish timeout for batch send HTTP requests.
 	defaultSendTimeout = time.Second * 60
@@ -489,7 +488,7 @@ func (b *batchAgg) fireBatch(events []*Event) {
 				body, err = json.Marshal(&errorBody)
 			}
 		} else {
-			body, err = ioutil.ReadAll(resp.Body)
+			body, err = io.ReadAll(resp.Body)
 		}
 		if err != nil {
 			b.enqueueErrResponses(

--- a/transmission/transmission_test.go
+++ b/transmission/transmission_test.go
@@ -66,7 +66,6 @@ func TestHnyTxAdd(t *testing.T) {
 	hnyTx.muster.Work = make(chan interface{}, 1)
 	hnyTx.responses = make(chan Response, 1)
 	hnyTx.responses <- placeholder
-	hnyTx.responses = hnyTx.responses
 
 	// default successful case
 	e := &Event{Metadata: "mmeetta"}
@@ -77,7 +76,7 @@ func TestHnyTxAdd(t *testing.T) {
 	testIsPlaceholderResponse(t, rsp, "work was simply queued; no response available yet")
 
 	// make the queue 0 length to force an overflow
-	hnyTx.muster.Work = make(chan interface{}, 0)
+	hnyTx.muster.Work = make(chan interface{})
 	hnyTx.Add(e)
 	rsp = testGetResponse(t, hnyTx.responses)
 	testErr(t, rsp.Err)
@@ -105,7 +104,7 @@ func TestHnyTxAdd(t *testing.T) {
 	// test blocking on response still gets an overflow down the channel
 	hnyTx.BlockOnSend = false
 	hnyTx.BlockOnResponse = true
-	hnyTx.muster.Work = make(chan interface{}, 0)
+	hnyTx.muster.Work = make(chan interface{})
 
 	hnyTx.responses <- placeholder
 	go hnyTx.Add(e)
@@ -132,7 +131,7 @@ func (f *FakeRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	if r.ContentLength == 0 {
 		panic("Expected a content length for all POST payloads.")
 	}
-	bodyBytes, _ := ioutil.ReadAll(r.Body)
+	bodyBytes, _ := io.ReadAll(r.Body)
 	if r.ContentLength != int64(len(bodyBytes)) {
 		panic("Content length did not match number of read bytes.")
 	}
@@ -496,7 +495,6 @@ type FancyFakeRoundTripper struct {
 	resp      *http.Response
 
 	// map of request apihost/writekey/dataset to intended response
-	respBody   string
 	respBodies map[string]string
 	respErr    error
 }
@@ -515,7 +513,7 @@ func (f *FancyFakeRoundTripper) RoundTrip(r *http.Request) (*http.Response, erro
 			if r.ContentLength == 0 {
 				panic("Expected a content length for all POST payloads.")
 			}
-			bodyBytes, _ := ioutil.ReadAll(r.Body)
+			bodyBytes, _ := io.ReadAll(r.Body)
 			if r.ContentLength != int64(len(bodyBytes)) {
 				panic("Content length did not match number of read bytes.")
 			}

--- a/transmission/transmission_test.go
+++ b/transmission/transmission_test.go
@@ -780,23 +780,23 @@ func TestFireBatchWithTooLargeEvent(t *testing.T) {
 		{
 			desc:        "large event",
 			fhData:      map[string]interface{}{"reallyREALLYBigColumn": randomString(1024 * 1024)},
-			expectedErr: "event exceeds max event size of 100000 bytes, API will not accept this event.",
+			expectedErr: "event exceeds max event size of 1000000 bytes, API will not accept this event.",
 		}, {
 			desc:        "large event with a name",
 			fhData:      map[string]interface{}{"name": "namae", "reallyREALLYBigColumn": randomString(1024 * 1024)},
-			expectedErr: "event exceeds max event size of 100000 bytes, API will not accept this event. Name: \"namae\"",
+			expectedErr: "event exceeds max event size of 1000000 bytes, API will not accept this event. Name: \"namae\"",
 		}, {
 			desc:        "large event with a service name",
 			fhData:      map[string]interface{}{"service.name": "servicio", "reallyREALLYBigColumn": randomString(1024 * 1024)},
-			expectedErr: "event exceeds max event size of 100000 bytes, API will not accept this event. Service Name: \"servicio\"",
+			expectedErr: "event exceeds max event size of 1000000 bytes, API will not accept this event. Service Name: \"servicio\"",
 		}, {
 			desc:        "large event with a name and service name",
 			fhData:      map[string]interface{}{"name": "nom", "service.name": "servicio", "reallyREALLYBigColumn": randomString(1024 * 1024)},
-			expectedErr: "event exceeds max event size of 100000 bytes, API will not accept this event. Name: \"nom\" Service Name: \"servicio\"",
+			expectedErr: "event exceeds max event size of 1000000 bytes, API will not accept this event. Name: \"nom\" Service Name: \"servicio\"",
 		}, {
 			desc:        "large event with other fields",
 			fhData:      map[string]interface{}{"f1": "racing", "team": "lotus", "reallyREALLYBigColumn": randomString(1024 * 1024)},
-			expectedErr: "event exceeds max event size of 100000 bytes, API will not accept this event.",
+			expectedErr: "event exceeds max event size of 1000000 bytes, API will not accept this event.",
 		},
 	}
 

--- a/transmission/transmission_test.go
+++ b/transmission/transmission_test.go
@@ -879,7 +879,7 @@ func TestFireBatchWithBrokenFirstEvent(t *testing.T) {
 		b.testBlocker.Wait()
 		resp := testGetResponse(t, b.responses)
 		testEquals(t, resp.Metadata, "meta 0")
-		testEquals(t, resp.Err.Error(), "event exceeds max event size of 100000 bytes, API will not accept this event.")
+		testEquals(t, resp.Err.Error(), "event exceeds max event size of 1000000 bytes, API will not accept this event.")
 		resp = testGetResponse(t, b.responses)
 		testEquals(t, resp.Metadata, "meta 1")
 		testEquals(t, resp.StatusCode, 202)

--- a/transmission/writer_test.go
+++ b/transmission/writer_test.go
@@ -2,7 +2,7 @@ package transmission
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -77,7 +77,7 @@ func TestWriterSenderAddingResponsesNonblocking(t *testing.T) {
 	// using the public SendRespanse method should add the response to the queue
 	// while honoring the block setting
 	w := &WriterSender{
-		W:                 ioutil.Discard,
+		W:                 io.Discard,
 		BlockOnResponses:  false,
 		ResponseQueueSize: 1,
 	}
@@ -123,7 +123,7 @@ func TestWriterSenderAddingResponsesBlocking(t *testing.T) {
 	// using the public SendRespanse method should add the response to the queue
 	// while honoring the block setting
 	w := &WriterSender{
-		W:                 ioutil.Discard,
+		W:                 io.Discard,
 		BlockOnResponses:  true,
 		ResponseQueueSize: 1,
 	}


### PR DESCRIPTION
## Which problem is this PR solving?

- We have increased the maximum ingestible size of an event in honeycomb to 1 MB; this allows libhoney to send them.

## Short description of the changes

- Bump `apiEventSizeMax` to 1_000_000. 
- Clean up some obsolete go-isms (things the linter was calling out)
- Bump the compressor version
- Remove go version 1.19 and 1.20, bump go mod to 1.21

Fixes #236.