### PR TITLE
feat: Add retry-after for 429 and 503

### DIFF
--- a/transmission/transmission.go
+++ b/transmission/transmission.go
@@ -492,7 +492,7 @@ func (b *batchAgg) fireBatch(events []*Event) {
 	b.metrics.Count("messages_sent", numEncoded)
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
 		b.metrics.Increment("send_errors")
 
 		var err error

--- a/transmission/transmission.go
+++ b/transmission/transmission.go
@@ -449,7 +449,7 @@ func (b *batchAgg) fireBatch(events []*Event) {
 			reader.Release()
 		}
 		// Handle 429 or 503 with Retry-After
-		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusServiceUnavailable {
+		if resp != nil && (resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusServiceUnavailable) {
 			retryAfter := resp.Header.Get("Retry-After")
 			sleepDur := time.Second // default 1s
 			if retryAfter != "" {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

When sending data to a system that is struggling to receive the data, Libhoney will not perform a retry-after. 

This adds a single retry attempt into the existing loop. 

## Short description of the changes

The only thing this does is waits until the retry-after and allows a single retry attempt.

Adding configurability for number of retries seems like a good idea, but I wanted to keep this PR minimal.

It will retry after 1 second if no retry-after header is sent. If it is sent, the retry-after can modify the delivery delay up to 60 seconds. I'm open to reducing the maximum delay to 10 or 30 seconds if folks think that makes more sense.

Also added `StatusAccepted` or code 202 as a non-error response.