### PR TITLE
chore: prepare v1.26.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # libhoney Changelog
 
+## 1.26.0 2025-08-25
+
+### Enhancements
+
+- feat: Add retry-after for 429 and 503 (#265) | @mterhar
+
 ## 1.25.0 2025-01-09
 
 Honeycomb's backend can now accept events with sizes up to 1 million bytes. This release bumps libhoney to

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 const (
-	Version string = "1.25.0"
+	Version string = "1.26.0"
 )


### PR DESCRIPTION
Updates changelog and version.
