### PR TITLE
feat: add bulk AddFields method to Event and fieldHolder

### DIFF
--- a/libhoney.go
+++ b/libhoney.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -639,20 +640,14 @@ func (f *fieldHolder) AddField(key string, val interface{}) {
 }
 
 // AddFields adds all key/value pairs from the map to the field holder in a
-// single lock acquisition. The underlying map is grown once to accommodate
-// the new entries, avoiding incremental growth.
+// single lock acquisition, avoiding per-field lock overhead.
 func (f *fieldHolder) AddFields(data map[string]interface{}) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 	if f.data == nil {
 		f.data = make(marshallableMap, len(data))
 	}
-	// Pre-grow: Go's map implementation will resize at most once if we
-	// write len(data) new keys into a map with sufficient capacity.
-	// There's no maps.Grow yet, so iterate directly.
-	for k, v := range data {
-		f.data[k] = v
-	}
+	maps.Copy(f.data, data)
 }
 
 // Add adds a complex data type to the event or builder on which it's called.

--- a/libhoney.go
+++ b/libhoney.go
@@ -638,6 +638,23 @@ func (f *fieldHolder) AddField(key string, val interface{}) {
 	f.data[key] = val
 }
 
+// AddFields adds all key/value pairs from the map to the field holder in a
+// single lock acquisition. The underlying map is grown once to accommodate
+// the new entries, avoiding incremental growth.
+func (f *fieldHolder) AddFields(data map[string]interface{}) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	if f.data == nil {
+		f.data = make(marshallableMap, len(data))
+	}
+	// Pre-grow: Go's map implementation will resize at most once if we
+	// write len(data) new keys into a map with sufficient capacity.
+	// There's no maps.Grow yet, so iterate directly.
+	for k, v := range data {
+		f.data[k] = v
+	}
+}
+
 // Add adds a complex data type to the event or builder on which it's called.
 // For structs, it adds each exported field. For maps, it adds each key/value.
 // Add will error on all other types.
@@ -765,6 +782,20 @@ func (e *Event) AddField(key string, val interface{}) {
 		return
 	}
 	e.fieldHolder.AddField(key, val)
+}
+
+// AddFields adds all key/value pairs from the map to the event in a single
+// lock acquisition. More efficient than calling AddField in a loop.
+//
+// Adds to an event that happen after it has been sent will return without
+// having any effect.
+func (e *Event) AddFields(data map[string]interface{}) {
+	e.sendLock.Lock()
+	defer e.sendLock.Unlock()
+	if e.sent {
+		return
+	}
+	e.fieldHolder.AddFields(data)
 }
 
 // Add adds a complex data type to the event on which it's called.

--- a/libhoney_test.go
+++ b/libhoney_test.go
@@ -148,6 +148,52 @@ func TestAddField(t *testing.T) {
 	testEquals(t, ev.data["boolVal"], true)
 }
 
+func TestAddFields(t *testing.T) {
+	resetPackageVars()
+	conf := Config{
+		WriteKey:   "aoeu",
+		Dataset:    "oeui",
+		SampleRate: 1,
+		APIHost:    "http://localhost:8081/",
+	}
+	Init(conf)
+	ev := NewEvent()
+	// Set one field individually first
+	ev.AddField("existing", "before")
+
+	ev.AddFields(map[string]interface{}{
+		"strVal":   "bar",
+		"intVal":   5,
+		"floatVal": 3.123,
+		"boolVal":  true,
+	})
+	testEquals(t, ev.data["existing"], "before")
+	testEquals(t, ev.data["strVal"], "bar")
+	testEquals(t, ev.data["intVal"], 5)
+	testEquals(t, ev.data["floatVal"], 3.123)
+	testEquals(t, ev.data["boolVal"], true)
+}
+
+func TestAddFieldsAfterSend(t *testing.T) {
+	resetPackageVars()
+	conf := Config{
+		WriteKey:   "aoeu",
+		Dataset:    "oeui",
+		SampleRate: 1,
+		APIHost:    "http://localhost:8081/",
+	}
+	Init(conf)
+	ev := NewEvent()
+	ev.AddField("before", "send")
+	_ = ev.Send()
+	ev.AddFields(map[string]interface{}{
+		"after": "send",
+	})
+	// After send, AddFields should be a no-op
+	_, ok := ev.data["after"]
+	testEquals(t, ok, false)
+}
+
 type Aich struct {
 	F1 string
 	F2 int


### PR DESCRIPTION
## Summary

Adds `AddFields(data map[string]interface{})` to both `fieldHolder` and `Event`. This writes all entries in a single lock acquisition instead of per-field `AddField` calls, avoiding N lock acquire/release cycles and allowing the map to grow once rather than incrementally.

We know libhoney-go is in maintenance mode, but this is needed for internal CPU savings in shepherd — the per-field `AddField` path accounts for 7.60% cumulative CPU in production profiles while we still have services using libhoney via beeline-go.

## How to Test

- `go test ./...` passes
- `TestAddFields` verifies bulk write with mixed types
- `TestAddFieldsAfterSend` verifies no-op after Send()

🤖 Generated with [Claude Code](https://claude.com/claude-code)