### PR TITLE
maint: bump minimum Go version to 1.24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,10 +17,10 @@ filters_publish: &filters_publish
 matrix_goversions: &matrix_goversions
   matrix:
     parameters:
-      goversion: ["21", "22", "23"]
+      goversion: ["24", "25", "26"]
 
 # Default version of Go to use for Go steps
-default_goversion: &default_goversion "21"
+default_goversion: &default_goversion "24"
 
 executors:
   go:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/honeycombio/libhoney-go
 
-go 1.21
+go 1.24
 
 require (
 	github.com/DataDog/zstd v1.5.7

--- a/libhoney.go
+++ b/libhoney.go
@@ -27,10 +27,6 @@ import (
 	statsd "gopkg.in/alexcesaro/statsd.v2"
 )
 
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
-
 const (
 	defaultSampleRate     = 1
 	defaultAPIHost        = "https://api.honeycomb.io/"

--- a/libhoney_test.go
+++ b/libhoney_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
@@ -752,12 +751,14 @@ func TestPresampledSendSamplerate(t *testing.T) {
 	}
 }
 
-// TestSendSamplerate verifies that Send samples
+// TestSendSamplerate verifies that Send samples events when SampleRate > 1.
+// With a sample rate of 2, each event has a 50% chance of being sent.
+// We send 1000 events and verify that the number sent is within a
+// reasonable statistical range (between 400 and 600).
 func TestSendSamplerate(t *testing.T) {
 	resetPackageVars()
 	Init(Config{})
 	testTx := &transmission.MockSender{}
-	rand.Seed(1)
 
 	dc, _ = NewClient(ClientConfig{
 		Transmission: testTx,
@@ -773,11 +774,14 @@ func TestSendSamplerate(t *testing.T) {
 		SampleRate: 2,
 		client:     dc,
 	}
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 1000; i++ {
 		err := ev.Send()
 		testOK(t, err)
 	}
-	testEquals(t, len(testTx.Events()), 4, "expected testTx num events incorrect")
+	got := len(testTx.Events())
+	if got < 400 || got > 600 {
+		t.Errorf("expected between 400 and 600 events, got %d", got)
+	}
 	for _, ev := range testTx.Events() {
 		testEquals(t, ev.SampleRate, uint(2))
 	}


### PR DESCRIPTION
## Which problem is this PR solving?

Go 1.24 makes `rand.Seed` a no-op for modules declaring `go 1.24`+, which causes `TestSendSamplerate` to fail non-deterministically. This blocks dependabot PRs like #274 that pull in dependencies requiring `go 1.24`.

## Short description of the changes

- Bump `go` directive in `go.mod` from 1.21 to 1.24
- Remove dead `init()` call to `rand.Seed(time.Now().UnixNano())` in `libhoney.go`
- Fix `TestSendSamplerate` to use statistical bounds (400-600 out of 1000 events) instead of asserting an exact count from a seeded PRNG
- Update CI matrix from Go 1.21/1.22/1.23 to 1.24/1.25/1.26