### PR TITLE
chore: prepare v1.27.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # libhoney Changelog
 
+## 1.27.0 2026-04-13
+
+### Enhancements
+
+- feat: add bulk AddFields method to Event and fieldHolder (#275) | @lizthegrey
+
+### Maintenance
+
+- maint: bump minimum Go version to 1.24 (#276) | @lizthegrey
+- maint(deps): bump github.com/klauspost/compress from 1.17.11 to 1.18.5 (#274) | @dependabot
+- maint(deps): bump github.com/stretchr/testify from 1.10.0 to 1.11.1 (#268) | @dependabot
+- ci(OTEL-125): remove pipeline-team dependabot reviewer (#273) | @JamieDanielson
+
 ## 1.26.0 2025-08-25
 
 ### Enhancements

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 const (
-	Version string = "1.26.0"
+	Version string = "1.27.0"
 )


### PR DESCRIPTION
## Which problem is this PR solving?

Prepare release v1.27.0.

## Short description of the changes

Bump version string to 1.27.0.

### Release notes

#### Enhancements

- feat: add bulk AddFields method to Event and fieldHolder (#275)

#### Maintenance

- maint: bump minimum Go version to 1.24 (#276)
- maint(deps): bump github.com/klauspost/compress from 1.17.11 to 1.18.5 (#274)
- maint(deps): bump github.com/stretchr/testify from 1.10.0 to 1.11.1 (#268)
- ci(OTEL-125): remove pipeline-team dependabot reviewer (#273)