### PR TITLE
feat: change AddFields to accept iter.Seq2[string, any]

### DIFF
--- a/libhoney.go
+++ b/libhoney.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"maps"
+	"iter"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -635,15 +635,14 @@ func (f *fieldHolder) AddField(key string, val interface{}) {
 	f.data[key] = val
 }
 
-// AddFields adds all key/value pairs from the map to the field holder in a
-// single lock acquisition, avoiding per-field lock overhead.
-func (f *fieldHolder) AddFields(data map[string]interface{}) {
+// AddFields adds all key/value pairs from the iterator to the field holder in
+// a single lock acquisition, avoiding per-field lock overhead.
+func (f *fieldHolder) AddFields(fields iter.Seq2[string, any]) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
-	if f.data == nil {
-		f.data = make(marshallableMap, len(data))
+	for k, v := range fields {
+		f.data[k] = v
 	}
-	maps.Copy(f.data, data)
 }
 
 // Add adds a complex data type to the event or builder on which it's called.
@@ -775,18 +774,18 @@ func (e *Event) AddField(key string, val interface{}) {
 	e.fieldHolder.AddField(key, val)
 }
 
-// AddFields adds all key/value pairs from the map to the event in a single
-// lock acquisition. More efficient than calling AddField in a loop.
+// AddFields adds all key/value pairs from the iterator to the event in a
+// single lock acquisition. More efficient than calling AddField in a loop.
 //
 // Adds to an event that happen after it has been sent will return without
 // having any effect.
-func (e *Event) AddFields(data map[string]interface{}) {
+func (e *Event) AddFields(fields iter.Seq2[string, any]) {
 	e.sendLock.Lock()
 	defer e.sendLock.Unlock()
 	if e.sent {
 		return
 	}
-	e.fieldHolder.AddFields(data)
+	e.fieldHolder.AddFields(fields)
 }
 
 // Add adds a complex data type to the event on which it's called.

--- a/libhoney_test.go
+++ b/libhoney_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
@@ -160,12 +161,12 @@ func TestAddFields(t *testing.T) {
 	// Set one field individually first
 	ev.AddField("existing", "before")
 
-	ev.AddFields(map[string]interface{}{
+	ev.AddFields(maps.All(map[string]interface{}{
 		"strVal":   "bar",
 		"intVal":   5,
 		"floatVal": 3.123,
 		"boolVal":  true,
-	})
+	}))
 	testEquals(t, ev.data["existing"], "before")
 	testEquals(t, ev.data["strVal"], "bar")
 	testEquals(t, ev.data["intVal"], 5)
@@ -185,9 +186,9 @@ func TestAddFieldsAfterSend(t *testing.T) {
 	ev := NewEvent()
 	ev.AddField("before", "send")
 	_ = ev.Send()
-	ev.AddFields(map[string]interface{}{
+	ev.AddFields(maps.All(map[string]interface{}{
 		"after": "send",
-	})
+	}))
 	// After send, AddFields should be a no-op
 	_, ok := ev.data["after"]
 	testEquals(t, ok, false)


### PR DESCRIPTION
## Which problem is this PR solving?

The `AddFields(map[string]interface{})` API forces callers to build an intermediate map even when they already have data in a different structure (e.g. a slice of key/value pairs). In Honeycomb's shepherd hot path, the map allocation and iteration accounts for ~1.8% cumulative CPU.

## Short description of the changes

- Change `fieldHolder.AddFields` and `Event.AddFields` from `map[string]interface{}` to `iter.Seq2[string, any]`
- Callers with existing maps can use `maps.All(m)` to adapt
- Tests updated to use `maps.All()`

Part of a 3-PR chain: **libhoney-go** → beeline-go → hound

🤖 Generated with [Claude Code](https://claude.com/claude-code)