### PR TITLE
perf: allocate correctly-sized map in AddFields to avoid rehashing

### DIFF
--- a/libhoney.go
+++ b/libhoney.go
@@ -643,8 +643,7 @@ func (f *fieldHolder) AddFields(data map[string]interface{}) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 	if f.data == nil {
-		f.data = make(marshallableMap, len(data))
-		maps.Copy(f.data, data)
+		f.data = maps.Clone(data)
 		return
 	}
 	if len(data) > len(f.data) {

--- a/libhoney.go
+++ b/libhoney.go
@@ -636,24 +636,22 @@ func (f *fieldHolder) AddField(key string, val interface{}) {
 }
 
 // AddFields adds all key/value pairs from the map to the field holder in a
-// single lock acquisition, avoiding per-field lock overhead. When the incoming
-// map is larger, the pointer is swapped to avoid rehashing during growth.
+// single lock acquisition, avoiding per-field lock overhead. When the combined
+// size may exceed the existing map's capacity, a new map is allocated to avoid
+// incremental rehashing during growth.
 func (f *fieldHolder) AddFields(data map[string]interface{}) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 	if f.data == nil {
-		f.data = marshallableMap(data)
+		f.data = make(marshallableMap, len(data))
+		maps.Copy(f.data, data)
 		return
 	}
 	if len(data) > len(f.data) {
-		// Iterate the smaller existing map; only copy keys that the
-		// incoming data doesn't already carry (new values win).
-		for k, v := range f.data {
-			if _, ok := data[k]; !ok {
-				data[k] = v
-			}
-		}
-		f.data = marshallableMap(data)
+		merged := make(marshallableMap, len(f.data)+len(data))
+		maps.Copy(merged, f.data)
+		maps.Copy(merged, data)
+		f.data = merged
 	} else {
 		maps.Copy(f.data, data)
 	}

--- a/libhoney.go
+++ b/libhoney.go
@@ -636,14 +636,27 @@ func (f *fieldHolder) AddField(key string, val interface{}) {
 }
 
 // AddFields adds all key/value pairs from the map to the field holder in a
-// single lock acquisition, avoiding per-field lock overhead.
+// single lock acquisition, avoiding per-field lock overhead. When the incoming
+// map is larger, the pointer is swapped to avoid rehashing during growth.
 func (f *fieldHolder) AddFields(data map[string]interface{}) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 	if f.data == nil {
-		f.data = make(marshallableMap, len(data))
+		f.data = marshallableMap(data)
+		return
 	}
-	maps.Copy(f.data, data)
+	if len(data) > len(f.data) {
+		// Iterate the smaller existing map; only copy keys that the
+		// incoming data doesn't already carry (new values win).
+		for k, v := range f.data {
+			if _, ok := data[k]; !ok {
+				data[k] = v
+			}
+		}
+		f.data = marshallableMap(data)
+	} else {
+		maps.Copy(f.data, data)
+	}
 }
 
 // Add adds a complex data type to the event or builder on which it's called.


### PR DESCRIPTION
## Which problem is this PR solving?

When `AddFields` receives a map larger than the event's existing field data, `maps.Copy(f.data, data)` forces the smaller destination map to grow/rehash multiple times. In shepherd's hot path, spans flush ~20+ attributes into events with only a few existing fields.

The prior approach (pointer-swap) solved the rehashing problem but mutated the caller's map as a side effect — writing existing field holder keys into the incoming `data` map. This is a surprising footgun for callers who reuse or inspect the map after calling `AddFields`.

## Short description of the changes

- When `len(data) > len(f.data)`, allocate a new map with `len(f.data)+len(data)` capacity, copy existing fields first, then incoming fields (preserving "new values win" semantics)
- When `f.data` is nil, allocate a new map and copy (no longer aliasing the caller's map)
- When `f.data` is already larger, fall back to `maps.Copy` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)