### PR TITLE
chore: prepare v1.27.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # libhoney Changelog
 
+## 1.27.1 2026-04-14
+
+### Fixes
+
+- perf: allocate correctly-sized map in AddFields to avoid rehashing and caller map mutation (#279) | @lizthegrey
+
 ## 1.27.0 2026-04-13
 
 ### Enhancements

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 const (
-	Version string = "1.27.0"
+	Version string = "1.27.1"
 )


### PR DESCRIPTION
## Summary

- Bump version to 1.27.1
- Add changelog entry for #279 (AddFields map allocation fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)